### PR TITLE
FEV-802 - Player V7 |Navigation 2.1.0| - Search results do not match the search value

### DIFF
--- a/src/components/navigation/navigation-item/NavigationItem.tsx
+++ b/src/components/navigation/navigation-item/NavigationItem.tsx
@@ -26,7 +26,6 @@ export interface ItemData extends RawItemData {
   shorthandTitle?: string;
   displayDescription?: string;
   shorthandDescription?: string;
-  indexedText: string;
   originalTime: number;
   hasShowMore: boolean;
   liveType: boolean;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -164,19 +164,6 @@ export const fillData = (
     item.shorthandDescription = elipsisDescription + '... ';
   }
 
-  // indexed text to save calculation at runtime + filter
-  let indexedText = '';
-  if (item.displayDescription) {
-    indexedText = item.displayDescription;
-  }
-  if (item.displayTitle) {
-    indexedText += ' ' + item.displayTitle;
-  }
-  if (item.displayTime) {
-    indexedText += ' ' + item.displayTime;
-  }
-  indexedText += ' ' + item.itemType;
-  item.indexedText = indexedText.toLowerCase();
   item.hasShowMore = item.displayDescription || item.shorthandDesctipyion;
   return item;
 };
@@ -260,7 +247,28 @@ export const filterDataBySearchQuery = (
   }
   const lowerQuery = searchQuery.toLowerCase();
   const filteredData = data.filter((item: ItemData) => {
-    return item.indexedText.indexOf(lowerQuery) > -1;
+    // search by title
+    if (
+      item.displayTitle &&
+      `${item.displayTitle}`.toLowerCase().indexOf(lowerQuery) > -1
+    ) {
+      return true;
+    }
+    // search by description
+    if (
+      item.displayDescription &&
+      `${item.displayDescription}`.toLowerCase().indexOf(lowerQuery) > -1
+    ) {
+      return true;
+    }
+    // search by time
+    if (
+      item.displayTime &&
+      /([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/.test(lowerQuery) &&
+      item.displayTime.indexOf(lowerQuery) > -1
+    ) {
+      return true;
+    }
   });
   //clear group values
   return clearGroupData(filteredData);


### PR DESCRIPTION
remove indexedText property that kept values from title, description, type and time and use more specific search logic to filter-out navigation items from list on search.
The changes can be made with "ternary operators" but implementation with "If then" more readable. 

Notes:
1) displayTitle and displayDescription converged to "string" for avoid case when displayTitle or displayDescription are numbers and .toLowerCase() will throw an error.
2) /([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/ regex - check if search query contains "m:ss"/"mm:ss" mask to filter navigation items by startTime (case "hh:mm:ss" also covered).