### PR TITLE
Player V7| |Navigation 2.1.0| - UI - Missing text in the 'No Results' slate

### DIFF
--- a/src/components/navigation/icons/EmptyList.scss
+++ b/src/components/navigation/icons/EmptyList.scss
@@ -1,0 +1,18 @@
+.empty-state-wrapper {
+    text-align: center;
+    margin-top: 40%;
+    margin-bottom: auto;
+    .primary-text,
+    .secondary-text {
+        color: #999999;
+    }
+    .primary-text {
+        margin-top: 12px;
+        font-size: 18px;
+        font-weight: bold;
+    }
+    .secondary-text {
+        margin-top: 4px;
+        font-size: 14px;
+    }
+}

--- a/src/components/navigation/icons/EmptyList.tsx
+++ b/src/components/navigation/icons/EmptyList.tsx
@@ -1,13 +1,9 @@
 import {h} from 'preact';
+import * as styles from './EmptyList.scss';
 
 export const EmptyList = () => {
-  const style = {
-    'text-align': 'center',
-    'margin-top': '50%',
-    'margin-bottom': 'auto',
-  };
   return (
-    <div style={style}>
+    <div className={styles.emptyStateWrapper}>
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="184"
@@ -124,6 +120,8 @@ export const EmptyList = () => {
           </g>
         </g>
       </svg>
+      <div className={styles.primaryText}>No Results Found</div>
+      <div className={styles.secondaryText}>Try a more general keyword</div>
     </div>
   );
 };


### PR DESCRIPTION
Add text in the 'No Results' slate according to design:
https://app.zeplin.io/project/5e5faf732d13a9120d1af1e0/screen/5ea52d909d340b2399b15afc
<img width="269" alt="Screen Shot 2021-02-16 at 2 57 01 AM" src="https://user-images.githubusercontent.com/51074448/108006110-374df200-7003-11eb-8fa2-6437dbfe1779.png">

