### PR TITLE
Player V7| |Navigation 2.1.0| - Edit page - Navigation plugin's kitchen sink pushes the video instead of be opened on top of it

### DIFF
--- a/src/navigation-plugin.tsx
+++ b/src/navigation-plugin.tsx
@@ -40,7 +40,6 @@ import {
   prepareLiveData,
   convertLiveItemsStartTime,
   cuePointTags,
-  parseExpandMode,
   itemTypesOrder,
   prepareItemTypesOrder,
   preparePendingCuepoints,
@@ -474,7 +473,9 @@ export class NavigationPlugin
     } = this._configs.pluginConfig;
     this._kitchenSinkItem = this._contribServices.kitchenSinkManager.add({
       label: 'Navigation',
-      expandMode: parseExpandMode(expandMode),
+      expandMode: expandMode === KitchenSinkExpandModes.OverTheVideo ?
+        KitchenSinkExpandModes.OverTheVideo :
+        KitchenSinkExpandModes.AlongSideTheVideo,
       renderIcon: () => (
         // TODO - resolve tabIndex race with the core.
         <button

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,3 @@
-import {KitchenSinkExpandModes} from '@playkit-js-contrib/ui';
 import {ObjectUtils} from '@playkit-js-contrib/common';
 import {
   ItemData,
@@ -401,16 +400,6 @@ export const checkResponce = (response: any, type?: any): boolean => {
     return true;
   }
   return false;
-};
-
-// TODO: consider move to contrib
-export const parseExpandMode = (value: string): KitchenSinkExpandModes => {
-  switch (value) {
-    case KitchenSinkExpandModes.AlongSideTheVideo:
-      return KitchenSinkExpandModes.AlongSideTheVideo;
-    default:
-      return KitchenSinkExpandModes.OverTheVideo;
-  }
 };
 
 export const prepareItemTypesOrder = (


### PR DESCRIPTION
use player enums to define plugin expand mode