### PR TITLE
FEV-748 - Player V7| Navigation - When opening from the navigation icon the search field is not focused in

### DIFF
--- a/src/components/navigation-search/navigation-search.tsx
+++ b/src/components/navigation-search/navigation-search.tsx
@@ -47,9 +47,9 @@ export class NavigationSearch extends Component<SearchProps, SearchState> {
     const {kitchenSinkActive, toggledWithEnter} = this.props;
     if (
       !previousProps.kitchenSinkActive &&
-      kitchenSinkActive &&
-      toggledWithEnter
+      kitchenSinkActive
     ) {
+      this._focusedByMouse = !toggledWithEnter;
       this._inputRef?.focus();
     }
   }
@@ -102,7 +102,7 @@ export class NavigationSearch extends Component<SearchProps, SearchState> {
           onBlur={this._onBlur}
           onMouseDown={this._handleMouseDown}
           tabIndex={1}
-          ref={node => {
+          ref={(node) => {
             this._inputRef = node;
           }}
         />

--- a/src/navigation-plugin.tsx
+++ b/src/navigation-plugin.tsx
@@ -458,11 +458,7 @@ export class NavigationPlugin
   };
 
   private _handleIconClick = (event: MouseEvent) => {
-    if (event.x === 0 && event.y === 0) {
-      this._triggeredByKeyboard = true;
-    } else {
-      this._triggeredByKeyboard = false;
-    }
+    this._triggeredByKeyboard = event.x === 0 && event.y === 0;
   };
 
   private _addKitchenSinkItem(): void {


### PR DESCRIPTION
From Dana Raviv comments:

- Search input should be focused after user clicked on navigation icon (from mouse OR keyboard);
- Accessibly should not be changed - search input should be Active (with blue border) only if search input got a focus by keyboard (by click on navigation icon from keyboard, tabing to search input by Tab key, click on clear-input icon by keyboard);