### PR TITLE
FEV-756 - Player V7| Navigation 0.0.4| - No tooltip is displayed while hovering over the auto-scroll button

### DIFF
--- a/src/components/navigation/autoscroll-button/autoscroll-button.scss
+++ b/src/components/navigation/autoscroll-button/autoscroll-button.scss
@@ -1,0 +1,11 @@
+.autoscrollButton {
+    width: 24px;
+    height: 24px;
+    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.5);
+    background-color: #01819a;
+    border-radius: 60px;
+    border: none;
+    padding-top: 4px;
+    padding-left: 4px;
+    cursor: pointer;
+}

--- a/src/components/navigation/autoscroll-button/autoscroll-button.tsx
+++ b/src/components/navigation/autoscroll-button/autoscroll-button.tsx
@@ -1,0 +1,15 @@
+import {h} from 'preact';
+import * as styles from './autoscroll-button.scss';
+import {AutoscrollIcon} from '../icons/AutoscrollIcon';
+
+interface AutoscrollButtonProps {
+  onClick: (event: Event) => void;
+}
+
+export const AutoscrollButton = ({onClick}: AutoscrollButtonProps) => {
+  return (
+    <button className={styles.autoscrollButton} onClick={onClick}>
+      <AutoscrollIcon />
+    </button>
+  );
+};

--- a/src/components/navigation/autoscroll-button/index.ts
+++ b/src/components/navigation/autoscroll-button/index.ts
@@ -1,0 +1,1 @@
+export * from "./autoscroll-button";

--- a/src/components/navigation/navigation.tsx
+++ b/src/components/navigation/navigation.tsx
@@ -20,8 +20,9 @@ import {
   itemTypesOrder,
   findCuepointType,
 } from '../../utils';
-import {AutoscrollIcon} from './icons/AutoscrollIcon';
 import {ItemData} from './navigation-item/NavigationItem';
+import {AutoscrollButton} from './autoscroll-button';
+const {Tooltip} = KalturaPlayer.ui.components;
 
 export interface SearchFilter {
   searchQuery: string;
@@ -378,9 +379,11 @@ export class Navigation extends Component<NavigationProps, NavigationState> {
       return null;
     }
     return (
-      <button className={styles.skipButton} onClick={this._enableAutoScroll}>
-        <AutoscrollIcon />
-      </button>
+      <div className={styles.autoscrollWrapper}>
+        <Tooltip label="Resume AutoScroll" type="left">
+          <AutoscrollButton onClick={this._enableAutoScroll}></AutoscrollButton>
+        </Tooltip>
+      </div>
     );
   };
 

--- a/src/components/navigation/navigaton.scss
+++ b/src/components/navigation/navigaton.scss
@@ -77,19 +77,10 @@
         padding: 0;
       }
     }
-    .skipButton {
-      width: 24px;
-      height: 24px;
-      box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.5);
-      background-color: #01819a;
+    .autoscrollWrapper {
       position: absolute;
       bottom: 14px;
       right: 16px;
-      border-radius: 60px;
-      border: none;
-      padding-top: 4px;
-      padding-left: 4px;
-      cursor: pointer;
     }
   }
 }


### PR DESCRIPTION
add tooltip to autoscroll button according to design
<img width="312" alt="Screen Shot 2021-03-25 at 1 24 55 PM" src="https://user-images.githubusercontent.com/51074448/112465959-f7023200-8d6d-11eb-887b-86bc629bb52f.png">

design: https://app.zeplin.io/project/5e5faf732d13a9120d1af1e0/screen/5edf3a7f62bac5b54deaeae1