### PR TITLE
FEV-847 - Navigation quepoints got incorrect start-time after DVR window moved

### DIFF
--- a/src/navigation-plugin.tsx
+++ b/src/navigation-plugin.tsx
@@ -103,7 +103,6 @@ export class NavigationPlugin
   private _triggeredByKeyboard = false;
   private _isLoading = false;
   private _hasError = false;
-  private _liveStartTime: number | null = null;
   private _itemsOrder = itemTypesOrder;
   private _itemsFilter = itemTypesOrder;
 
@@ -328,9 +327,8 @@ export class NavigationPlugin
       this._configs.playerConfig.provider.ks,
       this._configs.playerConfig.provider.env.serviceUrl,
       this._corePlugin.config.forceChaptersThumb,
-      this._liveStartTime,
       this._itemsOrder,
-      this._currentTime
+      this._currentTimeLive
     );
     this._listData = listData;
     this._pendingData = pendingData;

--- a/src/navigation-plugin.tsx
+++ b/src/navigation-plugin.tsx
@@ -188,6 +188,7 @@ export class NavigationPlugin
   }
 
   private _onTimedMetadataLoaded = (event: any): void => {
+    // TODO: handle dash format
     const id3TagCues = event.payload.cues.filter(
       (cue: any) => cue.value && cue.value.key === 'TEXT'
     );
@@ -443,7 +444,7 @@ export class NavigationPlugin
 
   private _onTimeUpdate = (): void => {
     // reduce refresh to only when the time really chanes - check UX speed
-    // TODO: hls has decimal currentTime format
+    // TODO: handle dash format
     const newTime = Math.ceil(this._corePlugin.player.currentTime);
     if (newTime === this._currentTime) {
       return;

--- a/src/navigation-plugin.tsx
+++ b/src/navigation-plugin.tsx
@@ -449,17 +449,21 @@ export class NavigationPlugin
     }
     this._currentTime = newTime;
     if (this._corePlugin.player.isLive()) {
-      if (this._id3Timestamp && this._id3Timestamp === this._currentTimeLive) {
-        // prevent updating if calculated _currentTimeLive value the same as _id3Timestamp
-        this._id3Timestamp = null;
-        return;
-      }
       if (this._id3Timestamp) {
+
+        if (this._id3Timestamp === this._currentTimeLive) {
+          // prevent updating if calculated _currentTimeLive value the same as _id3Timestamp
+          this._id3Timestamp = null;
+          return;
+        }
+        // update _currentTimeLive from id3Tag time
         this._currentTimeLive = this._id3Timestamp;
         this._id3Timestamp = null;
       } else {
+        // update _currentTimeLive between id3Tags
         this._currentTimeLive++;
       }
+      
       // compare startTime of pending items with _currentTimeLive
       if (this._pendingData.length) {
         const {listData, pendingData} = preparePendingCuepoints(

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -334,16 +334,6 @@ export const preparePendingCuepoints = (
   );
 };
 
-export const convertLiveItemsStartTime = (
-  data: Array<ItemData>,
-  liveStartTime: number
-): Array<ItemData> => {
-  return data.map((item: ItemData) => ({
-    ...item,
-    startTime: (item.createdAt || 0) - liveStartTime,
-  }));
-};
-
 export const prepareLiveData = (
   currentData: Array<ItemData>,
   pendingData: Array<ItemData>,
@@ -371,12 +361,6 @@ export const prepareLiveData = (
   receivedCuepoints = receivedCuepoints.map((cuepoint: ItemData) => {
     return fillData(cuepoint, ks, serviceUrl, forceChaptersThumb, true);
   });
-  if (liveStartTime) {
-    receivedCuepoints = convertLiveItemsStartTime(
-      receivedCuepoints,
-      liveStartTime
-    );
-  }
   const result: {
     listData: Array<ItemData>;
     pendingData: Array<ItemData>;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -315,14 +315,14 @@ export const getAvailableTabs = (
 
 export const preparePendingCuepoints = (
   currentData: Array<ItemData>,
-  currentPosition: number
+  currentTimeLive: number
 ): {listData: Array<ItemData>; pendingData: Array<ItemData>} => {
   return currentData.reduce(
     (
       acc: {listData: Array<ItemData>; pendingData: Array<ItemData>},
       item: ItemData
     ) => {
-      if (currentPosition < item.startTime) {
+      if (currentTimeLive < item.startTime) {
         return {
           listData: acc.listData,
           pendingData: [...acc.pendingData, item],
@@ -341,9 +341,8 @@ export const prepareLiveData = (
   ks: string,
   serviceUrl: string,
   forceChaptersThumb: boolean,
-  liveStartTime: number | null,
   itemOrder: typeof itemTypesOrder,
-  currentPosition: number
+  currentTimeLive: number
 ): {listData: Array<ItemData>; pendingData: Array<ItemData>} => {
   if (!newData || newData.length === 0) {
     // Wrong or empty data
@@ -364,10 +363,7 @@ export const prepareLiveData = (
   const result: {
     listData: Array<ItemData>;
     pendingData: Array<ItemData>;
-  } = preparePendingCuepoints(
-    receivedCuepoints,
-    liveStartTime ? currentPosition : 0
-  ); // set all live cuepoints as pending untill we get entry liveStartTime
+  } = preparePendingCuepoints(receivedCuepoints, currentTimeLive);
   const filteredPendingData = pendingData.filter((cuepoint: ItemData) => {
     return !result.listData.find((item: ItemData) => item.id === cuepoint.id);
   });


### PR DESCRIPTION
1) for live entries use absolute time of quepoints for seek and highlight;
2) use id3Tag to define initial `_currentTimeLive`;
3) increase `_currentTimeLive` every second and update `_currentTimeLive` once new `TIMED_METADATA` handled;