### PR TITLE
fix(fev-794): use raw assets to avoid cache issues

### DIFF
--- a/src/navigation-plugin.tsx
+++ b/src/navigation-plugin.tsx
@@ -617,6 +617,7 @@ export class NavigationPlugin
 
   private _fetchVodData = async () => {
     const requests: KalturaRequest<any>[] = [];
+    const entryId = (this._corePlugin.player as any).sources.id;
     let subTypesFilter = '';
     if (this._itemsFilter[itemTypes.Slide]) {
       subTypesFilter = `${subTypesFilter}${KalturaThumbCuePointSubType.slide},`;
@@ -627,7 +628,7 @@ export class NavigationPlugin
     if (subTypesFilter) {
       const request: CuePointListAction = new CuePointListAction({
         filter: new KalturaThumbCuePointFilter({
-          entryIdEqual: this._corePlugin.player.config.sources.id,
+          entryIdEqual: entryId,
           cuePointTypeEqual: KalturaCuePointType.thumb,
           subTypeIn: subTypesFilter,
         }),
@@ -640,7 +641,7 @@ export class NavigationPlugin
     if (this._itemsFilter[itemTypes.Hotspot]) {
       const request: CuePointListAction = new CuePointListAction({
         filter: new KalturaCuePointFilter({
-          entryIdEqual: this._corePlugin.player.config.sources.id,
+          entryIdEqual: entryId,
           cuePointTypeEqual: KalturaCuePointType.annotation,
         }),
       });
@@ -651,7 +652,7 @@ export class NavigationPlugin
     }
     if (this._itemsFilter[itemTypes.Caption]) {
       const request: CaptionAssetListAction = makeCaptionAssetListRequest(
-        this._corePlugin.player.config.sources.id
+        entryId
       );
       requests.push(request);
     }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,6 +5,8 @@ import {
 } from '../components/navigation/navigation-item/NavigationItem';
 const {get} = ObjectUtils;
 
+export const DEFAULT_SERVICE_URL = '//cdnapisec.kaltura.com/api_v3';
+
 export function getConfigValue( // TODO: consider move to contrib
   value: any,
   condition: (value: any) => boolean,
@@ -94,7 +96,7 @@ export const decodeString = (content: any): string => {
 export const fillData = (
   originalItem: any,
   ks: string,
-  serviceUrl: string,
+  serviceUrl: string = DEFAULT_SERVICE_URL,
   forceChaptersThumb = false,
   isLiveEntry = false
 ) => {
@@ -124,7 +126,7 @@ export const fillData = (
       item.displayDescription = decodeString(item.description);
       item.displayTitle = decodeString(item.title);
       if (item.assetId) {
-        item.previewImage = `${serviceUrl}/index.php/service/thumbAsset/action/serve/thumbAssetId/${item.assetId}/ks/${ks}?thumbParams:objectType=KalturaThumbParams&thumbParams:width=400`;
+        item.previewImage = `${serviceUrl}/index.php/service/thumbAsset/action/serve/thumbAssetId/${item.assetId}/ks/${ks}`;
       }
       switch (item.subType) {
         case 1:


### PR DESCRIPTION
1) use `player.sources.id` instead of `player.config.sources.id`;
2) added DEFAULT_SERVICE_URL;
3) removed `thumbParams` from assets url since it refers to incorrect asset (slide);