### PR TITLE
fix(FEV-1388): When broadcasting slide in preview and then go live, the slide appear duplicated in navigation plugin.

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -31,6 +31,8 @@ export const prepareCuePoint = (cuePoint: CuePoint, cuePointType: ItemTypes, isL
     id: cuePoint.id,
     startTime: cuePoint.startTime,
     displayTime: isLive ? '' : toHHMMSS(Math.floor(cuePoint.startTime)),
+    partnerData: metadata.partnerData,
+    tags: metadata.tags,
     itemType: cuePointType,
     displayTitle: '',
     displayDescription: [ItemTypes.Slide, ItemTypes.Chapter].includes(cuePointType) ? decodeString(metadata.description) : null,


### PR DESCRIPTION
 add missed properties to filter-out duplication for slides (https://github.com/kaltura/playkit-js-navigation/blob/master/src/utils/index.ts#L162-L169)