### PR TITLE
fix(FEV-1322): slides that were broadcasted prior to the archive appears without images in the navigation plugin

### DIFF
--- a/src/components/navigation/index.tsx
+++ b/src/components/navigation/index.tsx
@@ -203,7 +203,7 @@ export class Navigation extends Component<NavigationProps, NavigationState> {
       <NavigationList
         searchActive={searchFilter.searchQuery.length > 0}
         widgetWidth={widgetWidth}
-        autoScroll={this.state.autoscroll}
+        autoScroll={false} // TODO: temporary disable auto-scroll till https://kaltura.atlassian.net/browse/FEV-804 got a fix
         onSeek={this._handleSeek}
         onScroll={this._scrollTo}
         data={convertedData}
@@ -278,7 +278,7 @@ export class Navigation extends Component<NavigationProps, NavigationState> {
                 this._listElementRef = node;
               }}>
               {this._renderNavigation()}
-              {this._renderAutoscrollButton()}
+              {/* {this._renderAutoscrollButton()} // TODO: temporary disable auto-scroll till https://kaltura.atlassian.net/browse/FEV-804 got a fix */}
             </div>
           </div>
         )}

--- a/src/components/navigation/navigation-item/NavigationItem.scss
+++ b/src/components/navigation/navigation-item/NavigationItem.scss
@@ -10,6 +10,9 @@
   border-left: 2px solid transparent;
   -webkit-transition: background-color 0.3s;
   transition: background-color 0.3s;
+  &.hidden {
+    display: none;
+  }
   &:hover {
     background: rgba(255, 255, 255, 0.2);
   }
@@ -113,7 +116,7 @@
 
   .thumb-gradient {
     width: 100%;
-    min-height: 200px;
+    min-height: 100%;
     position: absolute;
     top: 2px;
     left: 0;

--- a/src/components/navigation/navigation-item/NavigationItem.tsx
+++ b/src/components/navigation/navigation-item/NavigationItem.tsx
@@ -50,7 +50,8 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
       selectedItem !== nextProps.selectedItem ||
       data !== nextProps.data ||
       nextState.expandText !== this.state.expandText ||
-      (selectedItem && nextState.imageLoaded && !this.state.imageLoaded) ||
+      nextState.imageLoaded !== this.state.imageLoaded ||
+      nextState.imageFailed !== this.state.imageFailed ||
       nextProps.widgetWidth !== widgetWidth
     ) {
       return true;
@@ -130,6 +131,7 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
 
   render({selectedItem, showIcon, data, ...otherProps}: NavigationItemProps) {
     const {id, previewImage, itemType, displayTime, groupData, displayTitle, shorthandTitle, hasShowMore, displayDescription} = data;
+    const {imageLoaded} = this.state;
     return (
       <div
         tabIndex={0}
@@ -137,7 +139,12 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
         ref={node => {
           this._itemElementRef = node;
         }}
-        className={[styles[groupData ? groupData : 'single'], styles.navigationItem, selectedItem ? styles.selected : null].join(' ')}
+        className={[
+          styles[groupData ? groupData : 'single'],
+          styles.navigationItem,
+          selectedItem ? styles.selected : null,
+          previewImage && !imageLoaded ? styles.hidden : null
+        ].join(' ')}
         data-entry-id={id}
         onClick={this._handleClickHandler}
         onKeyDown={this._handleKeyHandler}>

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -77,6 +77,11 @@ export const addGroupData = (cuepoints: Array<ItemData>): Array<ItemData> => {
     // mid items will have addGroupData=groupTypes.mid
     // last items will have addGroupData=groupTypes.last
     (prevArr: Array<any>, currentCuepoint: ItemData) => {
+      if (!currentCuepoint.displayTime) {
+        // live cue-points doesn't have displayTime
+        currentCuepoint.groupData = GroupTypes.first;
+        return [...prevArr, currentCuepoint];
+      }
       const prevItem = prevArr.length > 0 && prevArr[prevArr.length - 1];
       const prevPrevItem = prevArr.length > 1 && prevArr[prevArr.length - 2];
       if (prevItem && currentCuepoint.displayTime === prevItem.displayTime) {
@@ -89,9 +94,7 @@ export const addGroupData = (cuepoints: Array<ItemData>): Array<ItemData> => {
         }
         currentCuepoint.groupData = GroupTypes.last;
       }
-      // TODO - enforce order
-      prevArr.push(currentCuepoint);
-      return prevArr;
+      return [...prevArr, currentCuepoint];
     },
     []
   );


### PR DESCRIPTION
1) don't render slides that hasn't loaded image;
2) disable auto-scroll feature (https://kaltura.atlassian.net/browse/FEV-804);
3) fix groups of navigation items for live entries;