### PR TITLE
fix(FEV-1492): navigation plugin showing on Live entries even without chapters

### DIFF
--- a/src/navigation-plugin.tsx
+++ b/src/navigation-plugin.tsx
@@ -75,10 +75,6 @@ export class NavigationPlugin extends KalturaPlayer.core.BasePlugin {
 
     this._addPlayerListeners();
     this._registerCuePointTypes();
-
-    if (this.player.isLive()) {
-      this._createNavigationPlugin();
-    }
   }
 
   static isValid(): boolean {


### PR DESCRIPTION
**the issue:**
navigation plugin is showing on player when playing live content even when there's no data.

**the root cause:**
when media is loaded and player is live we call this._createNavigationPlugin().

**description of changes:**
remove invoking _createNavigationPlugin() when media is loaded.
once the plugin gets data, we either way call _createOrUpdatePlugin().

Solves FEV-1492