### PR TITLE
fix(FEV-1588): use the arrow keys by Jaws screen reader is not available inside navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "git+https://github.com/kaltura/playkit-js-navigation.git"
   },
   "dependencies": {
-    "@playkit-js/common": "^1.0.8",
+    "@playkit-js/common": "^1.0.14",
     "@playkit-js/ui-managers": "^1.3.0"
   },
   "devDependencies": {

--- a/src/components/navigation/navigation-item/NavigationItem.tsx
+++ b/src/components/navigation/navigation-item/NavigationItem.tsx
@@ -30,7 +30,7 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
   
   state = {expandText: false, imageLoaded: false, imageFailed: false, focused: false};
 
-  setFocus() {
+  public setFocus() {
     this._itemElementRef?.focus();
   }
 

--- a/src/components/navigation/navigation-item/NavigationItem.tsx
+++ b/src/components/navigation/navigation-item/NavigationItem.tsx
@@ -4,7 +4,7 @@ import * as styles from './NavigationItem.scss';
 import {GroupTypes, ItemData} from '../../../types';
 import {IconsFactory} from '../icons/IconsFactory';
 
-const {withText, Text} = KalturaPlayer.ui.preacti18n;
+const {Text} = KalturaPlayer.ui.preacti18n;
 
 export interface NavigationItemProps {
   data: ItemData;
@@ -13,9 +13,8 @@ export interface NavigationItemProps {
   widgetWidth: number;
   onClick: (time: number) => void;
   showIcon: boolean;
-  readLess?: string;
-  readMore?: string;
-  imageAlt?: string;
+  onNext: () => void;
+  onPrev: () => void;
 }
 
 export interface NavigationItemState {
@@ -25,20 +24,15 @@ export interface NavigationItemState {
   focused: boolean;
 }
 
-const translates = () => {
-  return {
-    readLess: <Text id="navigation.read_less">Read Less</Text>,
-    readMore: <Text id="navigation.read_more">Read More</Text>,
-    imageAlt: <Text id="navigation.image_alt">Slide Preview</Text>
-  };
-};
-
-@withText(translates)
 export class NavigationItem extends Component<NavigationItemProps, NavigationItemState> {
   private _itemElementRef: HTMLDivElement | null = null;
   private _textContainerRef: HTMLDivElement | null = null;
   
   state = {expandText: false, imageLoaded: false, imageFailed: false, focused: false};
+
+  setFocus() {
+    this._itemElementRef?.focus();
+  }
 
   matchHeight() {
     if (!this._textContainerRef || !this._itemElementRef) {
@@ -118,11 +112,11 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
     if (this.state.imageFailed) {
       return null;
     }
-    const {data, imageAlt} = this.props;
+    const {data} = this.props;
     const {previewImage} = data;
     const imageProps: Record<string, any> = {
       src: previewImage,
-      alt: imageAlt,
+      alt: <Text id="navigation.image_alt">Slide Preview</Text>,
       className: styles.thumbnail,
       onLoad: () => {
         this.setState({imageLoaded: true});
@@ -139,7 +133,7 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
     );
   };
 
-  render({selectedItem, showIcon, data, ...otherProps}: NavigationItemProps) {
+  render({selectedItem, showIcon, data}: NavigationItemProps) {
     const {id, previewImage, itemType, displayTime, groupData, displayTitle, shorthandTitle, hasShowMore, displayDescription} = data;
     const {imageLoaded} = this.state;
 
@@ -153,7 +147,7 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
     };
     
     return (
-      <A11yWrapper onClick={this._handleClick}>
+      <A11yWrapper onClick={this._handleClick} onDownKeyPressed={this.props.onNext} onUpKeyPressed={this.props.onPrev}>
         <div
           ref={node => {
             this._itemElementRef = node;
@@ -187,9 +181,9 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
 
               {displayDescription && this.state.expandText && <div className={styles.description}>{displayDescription}</div>}
               {hasShowMore && (
-                <A11yWrapper onClick={this._handleExpandChange}>
+                <A11yWrapper onClick={this._handleExpandChange} onDownKeyPressed={() => {}} onUpKeyPressed={() => {}}>
                   <div role={'button'} tabIndex={0} className={styles.showMoreButton}>
-                    {this.state.expandText ? otherProps.readLess : otherProps.readMore}
+                    {this.state.expandText ? <Text id="navigation.read_less">Read Less</Text> : <Text id="navigation.read_more">Read More</Text>}
                   </div>
                 </A11yWrapper>
               )}

--- a/src/components/navigation/navigation-list/NavigationList.tsx
+++ b/src/components/navigation/navigation-list/NavigationList.tsx
@@ -20,6 +20,12 @@ export interface Props {
 
 export class NavigationList extends Component<Props> {
   private _selectedElementY = 0;
+  private _itemsRefMap: Map<number, NavigationItem | null> = new Map();
+
+  componentWillUnmount() {
+    this._itemsRefMap = new Map();
+  }
+
   shouldComponentUpdate(nextProps: Readonly<Props>): boolean {
     if (
       !isMapsEqual(this.props.highlightedMap, nextProps.highlightedMap) ||
@@ -47,6 +53,22 @@ export class NavigationList extends Component<Props> {
     }
   };
 
+  private _setNavigationItemRef = (index: number, ref: NavigationItem | null) => {
+    return this._itemsRefMap.set(index, ref);
+  };
+
+  private _getItemRef = (index: number) => {
+    return this._itemsRefMap.get(index);
+  };
+
+  private _handleUpKeyPressed = (currentIndex: number) => {
+    this._getItemRef(currentIndex - 1)?.setFocus();
+  };
+
+  private _handleDownKeyPressed = (currentIndex: number) => {
+    this._getItemRef(currentIndex + 1)?.setFocus();
+  };
+
   render({data, widgetWidth, showItemsIcons, onSeek, highlightedMap, listDataContainCaptions, searchActive}: Props) {
     if (!data.length) {
       return listDataContainCaptions ? <EmptyState /> : <EmptyList showNoResultsText={searchActive} />;
@@ -56,6 +78,9 @@ export class NavigationList extends Component<Props> {
         {data.map((item: ItemData, index: number) => {
           return (
             <NavigationItem
+              ref={node => {
+                this._setNavigationItemRef(index, node);
+              }}
               widgetWidth={widgetWidth}
               onClick={onSeek}
               selectedItem={highlightedMap.has(item.id)}
@@ -63,6 +88,8 @@ export class NavigationList extends Component<Props> {
               data={item}
               onSelected={this.updateSelected}
               showIcon={showItemsIcons}
+              onNext={() => this._handleDownKeyPressed(index)}
+              onPrev={() => this._handleUpKeyPressed(index)}
             />
           );
         })}

--- a/yarn.lock
+++ b/yarn.lock
@@ -628,10 +628,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@playkit-js/common@^1.0.8":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@playkit-js/common/-/common-1.0.8.tgz#c78b94b15c3322cfb93b8c0d82d8fcb3efb708c9"
-  integrity sha512-iKbf7PKriPM/KgpCwh0IDmznma0JefpKhAiiUk2iZ/79AShoSXCMlpIHCKIGOfcQvkjvW7wQdh+8Fa9RyJQC6w==
+"@playkit-js/common@^1.0.14":
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/@playkit-js/common/-/common-1.0.14.tgz#e88114a17042156e11f3869cf2b9884b50438fd5"
+  integrity sha512-vwIoQ+kjWe6giS4c7UR7ZbPwRo9Ak4ZeEOBoXYN+9t5SvKBjHRTMsZ8r5JQo9n5HV6sd1MtSX9R3/lYcWQHovA==
   dependencies:
     linkify-it "^4.0.1"
 


### PR DESCRIPTION
**the issue:**
Jaws screen reader guides the user to use arrow keyboards to navigate throughout the items inside navigation body, which is currently not supported.

**solution:**
- upgrade common repo
- implement usage of up and down arrow keyboards
- discard usage of translates in navigation item

Solves [FEV-1588](https://kaltura.atlassian.net/browse/FEV-1588)