### PR TITLE
fix(FEV-1589): Screen reader (jaws) repeating the content/items inside navigation plugin twice - from top to bottom and from bottom to top

### DIFF
--- a/src/components/navigation/icons/EmptyList.tsx
+++ b/src/components/navigation/icons/EmptyList.tsx
@@ -119,8 +119,16 @@ export const EmptyList = withText(translates)(({showNoResultsText, noResultTitle
           </g>
         </g>
       </svg>
-      {showNoResultsText && <div className={styles.primaryText}>{noResultTitle}</div>}
-      {showNoResultsText && <div className={styles.secondaryText}>{noResultDescription}</div>}
+      {showNoResultsText && (
+        <div className={styles.primaryText} aria-label={noResultTitle}>
+          {noResultTitle}
+        </div>
+      )}
+      {showNoResultsText && (
+        <div className={styles.secondaryText} aria-label={noResultDescription}>
+          {noResultDescription}
+        </div>
+      )}
     </div>
   );
 });

--- a/src/components/navigation/navigation-list/NavigationList.tsx
+++ b/src/components/navigation/navigation-list/NavigationList.tsx
@@ -52,7 +52,7 @@ export class NavigationList extends Component<Props> {
       return listDataContainCaptions ? <EmptyState /> : <EmptyList showNoResultsText={searchActive} />;
     }
     return (
-      <div className={styles.navigationList} aria-live="polite">
+      <div className={styles.navigationList}>
         {data.map((item: ItemData, index: number) => {
           return (
             <NavigationItem


### PR DESCRIPTION
navigation root div has `aria-live="polite"` so list of navigation-items doesn't need another one aria-live