### PR TITLE
fix(FEV-1588): add up/down arrow keyboards navigation to the filter bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "git+https://github.com/kaltura/playkit-js-navigation.git"
   },
   "dependencies": {
-    "@playkit-js/common": "^1.0.14",
+    "@playkit-js/common": "^1.0.17",
     "@playkit-js/ui-managers": "^1.3.1"
   },
   "devDependencies": {

--- a/src/components/navigation-filter/navigation-filter.tsx
+++ b/src/components/navigation-filter/navigation-filter.tsx
@@ -87,7 +87,6 @@ class NavigationFilterComponent extends Component<FilterProps> {
             role="radio"
             type="checkbox"
             aria-checked={tab.isActive}
-            aria-orientation="horizontal"
             className={[styles.tab, tab.isActive ? styles.active : ''].join(' ')}
             style={style}
             ref={node => {

--- a/src/components/navigation-filter/navigation-filter.tsx
+++ b/src/components/navigation-filter/navigation-filter.tsx
@@ -37,6 +37,12 @@ export interface TabData {
 }
 
 class NavigationFilterComponent extends Component<FilterProps> {
+  private _tabsRefMap: Map<number, HTMLButtonElement | null> = new Map();
+
+  componentWillUnmount() {
+    this._tabsRefMap = new Map();
+  }
+
   shouldComponentUpdate(nextProps: Readonly<FilterProps>) {
     const {activeTab, availableTabs, totalResults} = this.props;
     if (activeTab !== nextProps.activeTab || availableTabs !== nextProps.availableTabs || totalResults !== nextProps.totalResults) {
@@ -48,15 +54,32 @@ class NavigationFilterComponent extends Component<FilterProps> {
   public _handleChange = (type: ItemTypes) => {
     this.props.onChange(type);
   };
+  private _getTabRef = (index: number) => {
+    return this._tabsRefMap.get(index);
+  };
 
-  public _renderTab = (tab: {isActive: boolean; type: ItemTypes; label?: string}) => {
+  private _setTabRef = (index: number, ref: HTMLButtonElement | null) => {
+    return this._tabsRefMap.set(index, ref);
+  };
+
+  private _handleUpKeyPressed = (currentIndex: number) => () => {
+    this._getTabRef(currentIndex - 1)?.focus();
+  };
+
+  private _handleDownKeyPressed = (currentIndex: number) => () => {
+    this._getTabRef(currentIndex + 1)?.focus();
+  };
+
+
+  public _renderTab = (tab: {isActive: boolean; type: ItemTypes; label?: string}, index: number) => {
     const style = {
       borderColor: IconColors[tab.type],
       backgroundColor: BackgroundColors[tab.type]
     };
     return (
       <Tooltip label={tab.label}>
-        <A11yWrapper onClick={() => this._handleChange(tab.type)}>
+        <A11yWrapper onClick={() => this._handleChange(tab.type)} onDownKeyPressed={this._handleDownKeyPressed(index)}
+                     onUpKeyPressed={this._handleUpKeyPressed(index)}>
           <button
             aria-label={tab.label}
             key={tab.type}
@@ -64,8 +87,12 @@ class NavigationFilterComponent extends Component<FilterProps> {
             role="radio"
             type="checkbox"
             aria-checked={tab.isActive}
+            aria-orientation="horizontal"
             className={[styles.tab, tab.isActive ? styles.active : ''].join(' ')}
-            style={style}>
+            style={style}
+            ref={node => {
+              this._setTabRef(index, node);
+            }}>
             {tab.type === ItemTypes.All ? (
               <span>{this.props[ItemTypes.All]}</span>
             ) : (
@@ -145,8 +172,8 @@ class NavigationFilterComponent extends Component<FilterProps> {
       <div className={styles.filterRoot}>
         {totalResults !== 0 && (
           <div className={styles.tabsWrapper} role="radiogroup">
-            {tabs.map(tab => {
-              return this._renderTab(tab);
+            {tabs.map((tab, index) => {
+              return this._renderTab(tab, index);
             })}
           </div>
         )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -628,10 +628,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@playkit-js/common@^1.0.14":
-  version "1.0.14"
-  resolved "https://registry.yarnpkg.com/@playkit-js/common/-/common-1.0.14.tgz#e88114a17042156e11f3869cf2b9884b50438fd5"
-  integrity sha512-vwIoQ+kjWe6giS4c7UR7ZbPwRo9Ak4ZeEOBoXYN+9t5SvKBjHRTMsZ8r5JQo9n5HV6sd1MtSX9R3/lYcWQHovA==
+"@playkit-js/common@^1.0.17":
+  version "1.0.17"
+  resolved "https://registry.yarnpkg.com/@playkit-js/common/-/common-1.0.17.tgz#4d0aee766e2839914df2adfe8e36b476e72ec16c"
+  integrity sha512-ENd2oOa5AMH3MZnaqe2MiNUUYz29KkN+fIeMWuIr0J4GpMsgyXk37slyBsNatb+M6M0irgAMvsbM7eCNDmYLPw==
   dependencies:
     linkify-it "^4.0.1"
 


### PR DESCRIPTION
**the issue:**
JAWS screen reader is guiding to use up/down arrows keyboard in order to navigate between the filter bar items.

**solution:**
add the ability to use up/down arrows keyboard for the filter bar navigation. 

Solves [FEV-1588](https://kaltura.atlassian.net/browse/FEV-1588)

[FEV-1588]: https://kaltura.atlassian.net/browse/FEV-1588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FEV-1588]: https://kaltura.atlassian.net/browse/FEV-1588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ