### PR TITLE
fix(FEV-1654): Chapter fails to remain highlighted after the player reaches a time were a slide it is displayed while the user has Chapters tab selected in navigation

### DIFF
--- a/src/components/navigation/index.tsx
+++ b/src/components/navigation/index.tsx
@@ -12,7 +12,8 @@ import {
   addGroupData,
   itemTypesOrder,
   findCuepointType,
-  isMapsEqual
+  isMapsEqual,
+  makeDisplayTime
 } from '../../utils';
 import {AutoscrollButton} from './autoscroll-button';
 import {ItemTypes, ItemData, HighlightedMap} from '../../types';
@@ -93,6 +94,7 @@ export class Navigation extends Component<NavigationProps, NavigationState> {
   }
 
   private _prepareNavigationData = (searchFilter: SearchFilter) => {
+    const {highlightedMap} = this.props;
     const {searchQuery, activeTab} = searchFilter;
     const filteredBySearchQuery = filterDataBySearchQuery(this.props.data, searchQuery);
     const listDataContainCaptions = searchQuery
@@ -100,12 +102,13 @@ export class Navigation extends Component<NavigationProps, NavigationState> {
       : findCuepointType(this.props.data, ItemTypes.Caption);
     const convertedData = addGroupData(filterDataByActiveTab(filteredBySearchQuery, activeTab));
 
+    const highlightedTime = highlightedMap.get(activeTab)!;
     const stateData: NavigationState = {
       ...this.state,
       listDataContainCaptions,
       convertedData,
       searchFilter: this._prepareSearchFilter(filteredBySearchQuery, searchFilter),
-      highlightedTime: this.props.highlightedMap.get(activeTab) || this.state.highlightedTime
+      highlightedTime: highlightedTime >= 0 ? makeDisplayTime(highlightedTime) : ''
     };
     if (this.state.searchFilter.searchQuery !== searchQuery) {
       // Any search interaction should stop autoscroll
@@ -115,7 +118,6 @@ export class Navigation extends Component<NavigationProps, NavigationState> {
       // if the user erases all the chars in the input field, the auto-scroll functionality will be kept
       stateData.autoscroll = true;
     }
-    console.log('>> stateData', stateData);
     this.setState(stateData);
   };
 

--- a/src/components/navigation/index.tsx
+++ b/src/components/navigation/index.tsx
@@ -95,14 +95,14 @@ export class Navigation extends Component<NavigationProps, NavigationState> {
 
   private _prepareNavigationData = (searchFilter: SearchFilter) => {
     const {highlightedMap} = this.props;
-    const {searchQuery, activeTab} = searchFilter;
+    const {searchQuery, activeTab, availableTabs} = searchFilter;
     const filteredBySearchQuery = filterDataBySearchQuery(this.props.data, searchQuery);
     const listDataContainCaptions = searchQuery
       ? findCuepointType(filteredBySearchQuery, ItemTypes.Caption)
       : findCuepointType(this.props.data, ItemTypes.Caption);
     const convertedData = addGroupData(filterDataByActiveTab(filteredBySearchQuery, activeTab));
 
-    const highlightedTime = highlightedMap.get(activeTab)!;
+    const highlightedTime = searchQuery ? Math.max(...availableTabs.map(tab => highlightedMap.get(tab)!)) : highlightedMap.get(activeTab)!;
     const stateData: NavigationState = {
       ...this.state,
       listDataContainCaptions,

--- a/src/components/navigation/index.tsx
+++ b/src/components/navigation/index.tsx
@@ -102,7 +102,8 @@ export class Navigation extends Component<NavigationProps, NavigationState> {
       : findCuepointType(this.props.data, ItemTypes.Caption);
     const convertedData = addGroupData(filterDataByActiveTab(filteredBySearchQuery, activeTab));
 
-    const highlightedTime = searchQuery ? Math.max(...availableTabs.map(tab => highlightedMap.get(tab)!)) : highlightedMap.get(activeTab)!;
+    const highlightedTime =
+      searchQuery && activeTab === ItemTypes.All ? Math.max(...availableTabs.map(tab => highlightedMap.get(tab)!)) : highlightedMap.get(activeTab)!;
     const stateData: NavigationState = {
       ...this.state,
       listDataContainCaptions,

--- a/src/components/navigation/navigation-item/NavigationItem.tsx
+++ b/src/components/navigation/navigation-item/NavigationItem.tsx
@@ -183,7 +183,7 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
   }
 
   render({selectedItem, showIcon, data}: NavigationItemProps) {
-    const {id, previewImage, itemType, displayTime, groupData, displayTitle, displayDescription} = data;
+    const {id, previewImage, itemType, displayTime, liveCuePoint, groupData, displayTitle, displayDescription} = data;
     const hasTitle = Boolean(displayTitle || displayDescription);
     const {imageLoaded} = this.state;
 
@@ -213,8 +213,8 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
           ].join(' ')}
           data-entry-id={id}
           {...a11yProps}>
-          <div className={[styles.metadata, displayTime ? styles.withTime : null].join(' ')}>
-            {displayTime && <span>{displayTime}</span>}
+          <div className={[styles.metadata, liveCuePoint ? null : styles.withTime].join(' ')}>
+            {!liveCuePoint && <span>{displayTime}</span>}
             {showIcon && (
               <div className={styles.iconWrapper}>
                 <IconsFactory iconType={itemType}></IconsFactory>

--- a/src/components/navigation/navigation-list/NavigationList.tsx
+++ b/src/components/navigation/navigation-list/NavigationList.tsx
@@ -3,8 +3,8 @@ import * as styles from './NavigationList.scss';
 import {NavigationItem} from '../navigation-item/NavigationItem';
 import {EmptyList} from '../icons/EmptyList';
 import {EmptyState} from '../icons/EmptyState';
-import {isDataEqual, isMapsEqual} from '../../../utils';
-import {ItemData, HighlightedMap} from '../../../types';
+import {isDataEqual} from '../../../utils';
+import {ItemData} from '../../../types';
 
 export interface Props {
   data: Array<ItemData>;
@@ -12,7 +12,7 @@ export interface Props {
   autoScroll: boolean;
   onScroll: (n: number) => void;
   widgetWidth: number;
-  highlightedMap: HighlightedMap;
+  highlightedTime: string;
   showItemsIcons: boolean;
   listDataContainCaptions: boolean;
   searchActive: boolean;
@@ -28,7 +28,7 @@ export class NavigationList extends Component<Props> {
 
   shouldComponentUpdate(nextProps: Readonly<Props>): boolean {
     if (
-      !isMapsEqual(this.props.highlightedMap, nextProps.highlightedMap) ||
+      this.props.highlightedTime !== nextProps.highlightedTime ||
       !isDataEqual(this.props.data, nextProps.data) ||
       nextProps.autoScroll !== this.props.autoScroll ||
       nextProps.listDataContainCaptions !== this.props.listDataContainCaptions ||
@@ -69,7 +69,7 @@ export class NavigationList extends Component<Props> {
     this._getItemRef(currentIndex + 1)?.setFocus();
   };
 
-  render({data, widgetWidth, showItemsIcons, onSeek, highlightedMap, listDataContainCaptions, searchActive}: Props) {
+  render({data, widgetWidth, showItemsIcons, onSeek, highlightedTime, listDataContainCaptions, searchActive}: Props) {
     if (!data.length) {
       return listDataContainCaptions ? <EmptyState /> : <EmptyList showNoResultsText={searchActive} />;
     }
@@ -83,7 +83,7 @@ export class NavigationList extends Component<Props> {
               }}
               widgetWidth={widgetWidth}
               onClick={onSeek}
-              selectedItem={highlightedMap.has(item.id)}
+              selectedItem={highlightedTime === item.displayTime}
               key={item.id}
               data={item}
               onSelected={this.updateSelected}

--- a/src/navigation-plugin.tsx
+++ b/src/navigation-plugin.tsx
@@ -49,7 +49,7 @@ export class NavigationPlugin extends KalturaPlayer.core.BasePlugin {
   constructor(name: string, player: KalturaPlayerTypes.Player, config: NavigationConfig) {
     super(name, player, config);
     this._player = player;
-    this._activeCuePointsMap = this._makeDefaultActiveCuePointsMap();
+    this._activeCuePointsMap = this._getDefaultActiveCuePointsMap();
     this._itemsOrder = prepareItemTypesOrder(this.config.itemsOrder);
     this._itemsFilter = isEmptyObject(this.config.itemsOrder) ? itemTypesOrder : config.itemsOrder;
   }
@@ -75,7 +75,7 @@ export class NavigationPlugin extends KalturaPlayer.core.BasePlugin {
     this._navigationData = filterDuplications(data);
   }
 
-  private _makeDefaultActiveCuePointsMap = () => {
+  private _getDefaultActiveCuePointsMap = () => {
     return new Map([
       [ItemTypes.All, -1],
       [ItemTypes.AnswerOnAir, -1],
@@ -230,7 +230,7 @@ export class NavigationPlugin extends KalturaPlayer.core.BasePlugin {
     });
     if (this._player.currentTime < Math.max(...Array.from(this._activeCuePointsMap.values()))) {
       // seek back happened, reset startTime for each tab
-      this._activeCuePointsMap = this._makeDefaultActiveCuePointsMap();
+      this._activeCuePointsMap = this._getDefaultActiveCuePointsMap();
     }
     if (navigationCuePoints.length) {
       const activeCueForAllTab = getLastItem(navigationCuePoints.filter(cue => this._getCuePointType(cue) !== ItemTypes.Caption));
@@ -378,7 +378,7 @@ export class NavigationPlugin extends KalturaPlayer.core.BasePlugin {
       this._navigationIcon = -1;
       this._navigationComponentRef = null;
     }
-    this._activeCuePointsMap = this._makeDefaultActiveCuePointsMap();
+    this._activeCuePointsMap = this._getDefaultActiveCuePointsMap();
     this._activeCaptionMapId = '';
     this._captionMap = new Map();
     this._liveFutureCuePointsMap = new Map();

--- a/src/navigation-plugin.tsx
+++ b/src/navigation-plugin.tsx
@@ -3,7 +3,7 @@ import {core} from 'kaltura-player-js';
 import {h} from 'preact';
 import {UpperBarManager, SidePanelsManager} from '@playkit-js/ui-managers';
 import {OnClickEvent} from '@playkit-js/common';
-import {itemTypesOrder, sortItems, filterDuplications, prepareCuePoint, prepareItemTypesOrder, isEmptyObject, getLast} from './utils';
+import {itemTypesOrder, sortItems, filterDuplications, prepareCuePoint, prepareItemTypesOrder, isEmptyObject, getLastItem} from './utils';
 import {Navigation} from './components/navigation';
 import {PluginButton} from './components/navigation/plugin-button';
 import {icons} from './components/icons';
@@ -233,7 +233,7 @@ export class NavigationPlugin extends KalturaPlayer.core.BasePlugin {
       this._activeCuePointsMap = this._makeDefaultActiveCuePointsMap();
     }
     if (navigationCuePoints.length) {
-      const cueForAllTab = getLast(navigationCuePoints.filter(cue => this._getCuePointType(cue) !== ItemTypes.Caption));
+      const cueForAllTab = getLastItem(navigationCuePoints.filter(cue => this._getCuePointType(cue) !== ItemTypes.Caption));
       if (cueForAllTab && cueForAllTab.startTime > this._activeCuePointsMap.get(ItemTypes.All)!) {
         // update activeCue startTime for All tab
         this._activeCuePointsMap.set(ItemTypes.All, cueForAllTab.startTime);

--- a/src/navigation-plugin.tsx
+++ b/src/navigation-plugin.tsx
@@ -233,10 +233,10 @@ export class NavigationPlugin extends KalturaPlayer.core.BasePlugin {
       this._activeCuePointsMap = this._makeDefaultActiveCuePointsMap();
     }
     if (navigationCuePoints.length) {
-      const cueForAllTab = getLastItem(navigationCuePoints.filter(cue => this._getCuePointType(cue) !== ItemTypes.Caption));
-      if (cueForAllTab && cueForAllTab.startTime > this._activeCuePointsMap.get(ItemTypes.All)!) {
+      const activeCueForAllTab = getLastItem(navigationCuePoints.filter(cue => this._getCuePointType(cue) !== ItemTypes.Caption));
+      if (activeCueForAllTab && activeCueForAllTab.startTime > this._activeCuePointsMap.get(ItemTypes.All)!) {
         // update activeCue startTime for All tab
-        this._activeCuePointsMap.set(ItemTypes.All, cueForAllTab.startTime);
+        this._activeCuePointsMap.set(ItemTypes.All, activeCueForAllTab.startTime);
       }
       navigationCuePoints.forEach(item => {
         if (this._player.isLive() && this._liveFutureCuePointsMap.has(item.id)) {

--- a/src/types/navigation-item-data.ts
+++ b/src/types/navigation-item-data.ts
@@ -49,7 +49,8 @@ export interface ItemData extends RawItemData {
   groupData: GroupTypes | null;
   displayTitle: string;
   displayDescription: string | null;
+  liveCuePoint: boolean;
 }
 
-export type HighlightedMap = Map<string, true>;
+export type HighlightedMap = Map<ItemTypes, string | null>;
 export type CuePointsMap = Map<string, ItemData>;

--- a/src/types/navigation-item-data.ts
+++ b/src/types/navigation-item-data.ts
@@ -52,5 +52,5 @@ export interface ItemData extends RawItemData {
   liveCuePoint: boolean;
 }
 
-export type HighlightedMap = Map<ItemTypes, string | null>;
+export type HighlightedMap = Map<ItemTypes, number>;
 export type CuePointsMap = Map<string, ItemData>;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -76,7 +76,7 @@ export const addGroupData = (cuepoints: Array<ItemData>): Array<ItemData> => {
         currentCuepoint.groupData = GroupTypes.first;
         return [...prevArr, currentCuepoint];
       }
-      const prevItem = prevArr.length > 0 && getLastItem(prevArr);
+      const prevItem = getLastItem(prevArr);
       const prevPrevItem = prevArr.length > 1 && prevArr[prevArr.length - 2];
       if (prevItem && currentCuepoint.displayTime === prevItem.displayTime) {
         if (prevPrevItem.displayTime === prevItem.displayTime) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -10,7 +10,7 @@ export const itemTypesOrder: Record<string, number> = {
   [ItemTypes.Caption]: 5
 };
 
-export const getLast = <T>(arr: Array<T>) => {
+export const getLastItem = <T>(arr: Array<T>) => {
   return arr[arr.length - 1];
 };
 
@@ -76,7 +76,7 @@ export const addGroupData = (cuepoints: Array<ItemData>): Array<ItemData> => {
         currentCuepoint.groupData = GroupTypes.first;
         return [...prevArr, currentCuepoint];
       }
-      const prevItem = prevArr.length > 0 && getLast(prevArr);
+      const prevItem = prevArr.length > 0 && getLastItem(prevArr);
       const prevPrevItem = prevArr.length > 1 && prevArr[prevArr.length - 2];
       if (prevItem && currentCuepoint.displayTime === prevItem.displayTime) {
         if (prevPrevItem.displayTime === prevItem.displayTime) {
@@ -213,13 +213,13 @@ export const isDataEqual = (prevData: ItemData[], nextData: ItemData[]): boolean
     if (prevData[0].id !== nextData[0].id) {
       return false;
     }
-    if (getLast(prevData).id !== getLast(nextData).id) {
+    if (getLastItem(prevData).id !== getLastItem(nextData).id) {
       return false;
     }
     if (prevData[0].text && nextData[0].text && prevData[0].text !== nextData[0].text) {
       return false;
     }
-    if (getLast(prevData).text && getLast(nextData).text && getLast(prevData).text !== getLast(nextData).text) {
+    if (getLastItem(prevData).text && getLastItem(nextData).text && getLastItem(prevData).text !== getLastItem(nextData).text) {
       return false;
     }
   }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -210,16 +210,20 @@ export const isDataEqual = (prevData: ItemData[], nextData: ItemData[]): boolean
     return false;
   }
   if (prevData.length && nextData.length) {
-    if (prevData[0].id !== nextData[0].id) {
+    const prevDataFirst = prevData[0];
+    const nextDataFirst = nextData[0];
+    if (prevDataFirst.id !== nextDataFirst.id) {
       return false;
     }
-    if (getLastItem(prevData).id !== getLastItem(nextData).id) {
+    const prevDataLast = getLastItem(prevData);
+    const nextDataLast = getLastItem(nextData);
+    if (prevDataLast.id !== nextDataLast.id) {
       return false;
     }
-    if (prevData[0].text && nextData[0].text && prevData[0].text !== nextData[0].text) {
+    if (prevDataFirst.text && nextDataFirst.text && prevDataFirst.text !== nextDataFirst.text) {
       return false;
     }
-    if (getLastItem(prevData).text && getLastItem(nextData).text && getLastItem(prevData).text !== getLastItem(nextData).text) {
+    if (prevDataLast.text && nextDataLast.text && prevDataLast.text !== nextDataLast.text) {
       return false;
     }
   }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -10,6 +10,10 @@ export const itemTypesOrder: Record<string, number> = {
   [ItemTypes.Caption]: 5
 };
 
+export const getLast = <T>(arr: Array<T>) => {
+  return arr[arr.length - 1];
+};
+
 export const makeDisplayTime = (startTime: number) => {
   return toHHMMSS(Math.floor(startTime));
 };
@@ -72,7 +76,7 @@ export const addGroupData = (cuepoints: Array<ItemData>): Array<ItemData> => {
         currentCuepoint.groupData = GroupTypes.first;
         return [...prevArr, currentCuepoint];
       }
-      const prevItem = prevArr.length > 0 && prevArr[prevArr.length - 1];
+      const prevItem = prevArr.length > 0 && getLast(prevArr);
       const prevPrevItem = prevArr.length > 1 && prevArr[prevArr.length - 2];
       if (prevItem && currentCuepoint.displayTime === prevItem.displayTime) {
         if (prevPrevItem.displayTime === prevItem.displayTime) {
@@ -209,17 +213,13 @@ export const isDataEqual = (prevData: ItemData[], nextData: ItemData[]): boolean
     if (prevData[0].id !== nextData[0].id) {
       return false;
     }
-    if (prevData[prevData.length - 1].id !== nextData[nextData.length - 1].id) {
+    if (getLast(prevData).id !== getLast(nextData).id) {
       return false;
     }
     if (prevData[0].text && nextData[0].text && prevData[0].text !== nextData[0].text) {
       return false;
     }
-    if (
-      prevData[prevData.length - 1].text &&
-      nextData[nextData.length - 1].text &&
-      prevData[prevData.length - 1].text !== nextData[nextData.length - 1].text
-    ) {
+    if (getLast(prevData).text && getLast(nextData).text && getLast(prevData).text !== getLast(nextData).text) {
       return false;
     }
   }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -10,6 +10,10 @@ export const itemTypesOrder: Record<string, number> = {
   [ItemTypes.Caption]: 5
 };
 
+export const makeDisplayTime = (startTime: number) => {
+  return toHHMMSS(Math.floor(startTime));
+};
+
 export const decodeString = (content: any): string => {
   if (typeof content !== 'string') {
     return content;
@@ -28,11 +32,12 @@ export const prepareCuePoint = (cuePoint: CuePoint, cuePointType: ItemTypes, isL
     cuePointType,
     id: cuePoint.id,
     startTime: cuePoint.startTime,
-    displayTime: isLive ? '' : toHHMMSS(Math.floor(cuePoint.startTime)),
+    displayTime: makeDisplayTime(cuePoint.startTime),
     partnerData: metadata.partnerData,
     tags: metadata.tags,
     itemType: cuePointType,
     displayTitle: '',
+    liveCuePoint: isLive,
     displayDescription: [ItemTypes.Slide, ItemTypes.Chapter].includes(cuePointType) ? decodeString(metadata.description) : null,
     previewImage: null,
     groupData: null


### PR DESCRIPTION
The PR fixes next issue:
If plugin keep active cues by ID (active cues takes from TIMED_METADATA_CHANGED event) user can't use navigation item filter properly, because requirement for the plugin - display latest active cue for each filter tab.
Goal of changes is next: instead of keeps active cues by ID - keeps "highlighter" time for each type of navigation items. Then if user change navigation filter - plugin correctly displays latest active item for filtered type.