### PR TITLE
fix(FEV-1623): The transition animation is broken when the side panel is activated

### DIFF
--- a/.github/workflows/common_test.yml
+++ b/.github/workflows/common_test.yml
@@ -1,0 +1,13 @@
+name: Run tests
+
+on:
+  pull_request:
+    types: 
+      - opened
+      - reopened
+      - edited
+  
+jobs:
+   test:
+    uses: kaltura/playkit-js-common/.github/workflows/test.yml@master
+    secrets: inherit

--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -161,7 +161,7 @@ describe('Navigation plugin', () => {
           cy.get("[aria-label='Search in video']").type('c');
           kalturaPlayer.currentTime = 12;
           cy.get('[data-entry-id="1_nkiuwh50-1"]').should('have.attr', 'aria-current', 'true');
-          cy.get("[aria-label='Chapters']").click();
+          cy.get("[aria-label='list Chapters']").click();
           cy.get('[data-entry-id="1_02sihd5j"]').should('have.attr', 'aria-current', 'true');
         });
       });
@@ -199,10 +199,10 @@ describe('Navigation plugin', () => {
       preparePage({expandOnFirstPlay: true}, {muted: true, autoplay: true});
       cy.get('[data-testid="navigation_root"]').within(() => {
         // default state
-        const tabAll = cy.get("[aria-label='All']").should('be.visible').should('have.attr', 'aria-checked', 'true');
-        const tabChapters = cy.get("[aria-label='Chapters']").should('be.visible').should('have.attr', 'aria-checked', 'false');
-        const tabSlides = cy.get("[aria-label='Slides']").should('be.visible').should('have.attr', 'aria-checked', 'false');
-        const tabHotspots = cy.get("[aria-label='Hotspots']").should('be.visible').should('have.attr', 'aria-checked', 'false');
+        const tabAll = cy.get("[aria-label='list All']").should('be.visible').should('have.attr', 'aria-checked', 'true');
+        const tabChapters = cy.get("[aria-label='list Chapters']").should('be.visible').should('have.attr', 'aria-checked', 'false');
+        const tabSlides = cy.get("[aria-label='list Slides']").should('be.visible').should('have.attr', 'aria-checked', 'false');
+        const tabHotspots = cy.get("[aria-label='list Hotspots']").should('be.visible').should('have.attr', 'aria-checked', 'false');
         cy.get("[aria-label='Captions']").should('not.exist');
         cy.get("[aria-label='AoA']").should('not.exist');
 
@@ -219,12 +219,12 @@ describe('Navigation plugin', () => {
         // apply search
         cy.get("[aria-label='Captions']").should('not.exist');
         cy.get("[aria-label='Search in video']").type('c');
-        cy.get("[aria-label='All']").should('be.visible');
-        cy.get("[aria-label='Chapters']").should('be.visible');
+        cy.get("[aria-label='list All']").should('be.visible');
+        cy.get("[aria-label='list Chapters']").should('be.visible');
         cy.get("[aria-label='Slides']").should('not.exist');
         cy.get("[aria-label='Hotspots']").should('not.exist');
         cy.get("[aria-label='AoA']").should('not.exist');
-        const tabCaptions = cy.get("[aria-label='Captions']").should('be.visible').click();
+        const tabCaptions = cy.get("[aria-label='list Captions']").should('be.visible').click();
         tabCaptions.should('have.attr', 'aria-checked', 'true');
         cy.get('[data-testid="navigation_list"]').children().should('have.length', 5);
       });

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "git+https://github.com/kaltura/playkit-js-navigation.git"
   },
   "dependencies": {
-    "@playkit-js/common": "^1.1.1",
+    "@playkit-js/common": "^1.1.2",
     "@playkit-js/playkit-js-ui": "^0.73.0",
     "@playkit-js/ui-managers": "^1.3.2"
   },

--- a/src/components/close-button/index.tsx
+++ b/src/components/close-button/index.tsx
@@ -1,6 +1,6 @@
 import {h} from 'preact';
 import * as styles from './close-button.scss';
-import {A11yWrapper} from '@playkit-js/common';
+import {A11yWrapper} from '@playkit-js/common/dist/hoc/a11y-wrapper';
 import {icons} from '../icons';
 const {Icon} = KalturaPlayer.ui.components;
 

--- a/src/components/error/error.tsx
+++ b/src/components/error/error.tsx
@@ -1,5 +1,5 @@
 import {h} from 'preact';
-import {A11yWrapper} from '@playkit-js/common';
+import {A11yWrapper} from '@playkit-js/common/dist/hoc/a11y-wrapper';
 import * as styles from './error.scss';
 import {ErrorIconSVG} from '../icons/error-icon';
 const {withText, Text} = KalturaPlayer.ui.preacti18n;

--- a/src/components/navigation-filter/navigation-filter.tsx
+++ b/src/components/navigation-filter/navigation-filter.tsx
@@ -1,5 +1,5 @@
 import {h, Component, Fragment} from 'preact';
-import {A11yWrapper} from '@playkit-js/common';
+import {A11yWrapper} from '@playkit-js/common/dist/hoc/a11y-wrapper';
 import * as styles from './navigation-filter.scss';
 import {ItemTypes} from '../../types';
 import {IconsFactory} from '../navigation/icons/IconsFactory';

--- a/src/components/navigation-search/navigation-search.tsx
+++ b/src/components/navigation-search/navigation-search.tsx
@@ -1,5 +1,5 @@
 import {h, Component} from 'preact';
-import {InputField} from '@playkit-js/common';
+import {InputField} from '@playkit-js/common/dist/components/input-field';
 import {debounce} from '../../utils';
 
 const {withText, Text} = KalturaPlayer.ui.preacti18n;
@@ -38,7 +38,7 @@ class NavigationSearchComponent extends Component<SearchProps> {
   componentDidUpdate(previousProps: Readonly<SearchProps>): void {
     const {kitchenSinkActive, toggledWithEnter} = this.props;
     if (!previousProps.kitchenSinkActive && kitchenSinkActive && toggledWithEnter) {
-      this._inputField?.setFocus();
+      this._inputField?.setFocus({ preventScroll: true });
     }
   }
 

--- a/src/components/navigation/autoscroll-button/autoscroll-button.tsx
+++ b/src/components/navigation/autoscroll-button/autoscroll-button.tsx
@@ -1,6 +1,6 @@
 import {h} from 'preact';
 import * as styles from './autoscroll-button.scss';
-import {A11yWrapper, OnClick} from '@playkit-js/common';
+import {A11yWrapper, OnClick} from '@playkit-js/common/dist/hoc/a11y-wrapper';
 
 const {withText, Text} = KalturaPlayer.ui.preacti18n;
 const {Tooltip} = KalturaPlayer.ui.components;

--- a/src/components/navigation/index.tsx
+++ b/src/components/navigation/index.tsx
@@ -1,6 +1,6 @@
 import {h, Component} from 'preact';
 import * as styles from './navigaton.scss';
-import {OnClick} from '@playkit-js/common';
+import {OnClick} from '@playkit-js/common/dist/hoc/a11y-wrapper';
 import {NavigationList} from './navigation-list/NavigationList';
 import {NavigationSearch} from '../navigation-search/navigation-search';
 import {NavigationFilter} from '../navigation-filter';

--- a/src/components/navigation/navigation-item/NavigationItem.tsx
+++ b/src/components/navigation/navigation-item/NavigationItem.tsx
@@ -1,5 +1,5 @@
 import {Component, h} from 'preact';
-import {A11yWrapper, OnClickEvent} from '@playkit-js/common';
+import {A11yWrapper, OnClickEvent} from '@playkit-js/common/dist/hoc/a11y-wrapper';
 import * as styles from './NavigationItem.scss';
 import {GroupTypes, ItemData} from '../../../types';
 import {IconsFactory} from '../icons/IconsFactory';

--- a/src/components/navigation/plugin-button/index.tsx
+++ b/src/components/navigation/plugin-button/index.tsx
@@ -2,7 +2,7 @@ import {h} from 'preact';
 import * as styles from './plugin-button.scss';
 import {ui} from 'kaltura-player-js';
 import {icons} from '../../icons';
-import {A11yWrapper, OnClick} from '@playkit-js/common';
+import {A11yWrapper, OnClick} from '@playkit-js/common/dist/hoc/a11y-wrapper';
 
 const {Tooltip, Icon} = KalturaPlayer.ui.components;
 const {withText, Text} = KalturaPlayer.ui.preacti18n;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,5 +9,5 @@ const NAME = __NAME__;
 export {NavigationPlugin as Plugin};
 export {VERSION, NAME};
 
-const pluginName: string = 'navigation';
+const pluginName: string = 'navigationLocal';
 KalturaPlayer.core.registerPlugin(pluginName, NavigationPlugin);

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,5 +9,5 @@ const NAME = __NAME__;
 export {NavigationPlugin as Plugin};
 export {VERSION, NAME};
 
-const pluginName: string = 'navigationLocal';
+const pluginName: string = 'navigation';
 KalturaPlayer.core.registerPlugin(pluginName, NavigationPlugin);

--- a/src/navigation-plugin.tsx
+++ b/src/navigation-plugin.tsx
@@ -2,7 +2,7 @@
 import {core} from 'kaltura-player-js';
 import {h} from 'preact';
 import {UpperBarManager, SidePanelsManager} from '@playkit-js/ui-managers';
-import {OnClickEvent} from '@playkit-js/common';
+import {OnClickEvent} from '@playkit-js/common/dist/hoc/a11y-wrapper';
 import {itemTypesOrder, sortItems, filterDuplications, prepareCuePoint, prepareItemTypesOrder, isEmptyObject, getLastItem} from './utils';
 import {Navigation} from './components/navigation';
 import {PluginButton} from './components/navigation/plugin-button';

--- a/yarn.lock
+++ b/yarn.lock
@@ -130,10 +130,10 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
-"@playkit-js/common@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@playkit-js/common/-/common-1.1.1.tgz#b0c21e96794dd66622c1bbcfdf0373aad2b9f5dc"
-  integrity sha512-75l2CogQtpLggXp/FxjNsPbV+FKZ1MxhhLJolBwJYsKV/tyd61aKcbU81EzcyyVefkxYEcLdt2YrkFW64isTKw==
+"@playkit-js/common@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@playkit-js/common/-/common-1.1.2.tgz#35e86126d87f9006795033bce7e3d9a1b885b61f"
+  integrity sha512-N/mcYl9sKpdRs56lUwNxdRZZtljQE35+K8XeY15d7Vcalnh5tWgcY4zqTYAqT3mz4wL1hY15fHe5rYuDF0WH1A==
   dependencies:
     "@playkit-js/playkit-js-ui" "^0.74.0"
     linkify-it "^4.0.1"


### PR DESCRIPTION
The transition animation is broken when the side panel is activated

solve FEV-1623

1. fix transition animation
2. import from `@playkit-js/common` only components that Navigation plugin uses

dependent PR: https://github.com/kaltura/playkit-js-common/pull/10