### PR TITLE
fix(FEC-13097): IVQ in Navigation - for xs player, the "Answered" tag should be in a new line

### DIFF
--- a/src/components/navigation/navigation-item/QuizTitle.scss
+++ b/src/components/navigation/navigation-item/QuizTitle.scss
@@ -35,7 +35,8 @@
 }
 
 :global(.playkit-size-sm),
-:global(.playkit-size-ty) {
+:global(.playkit-size-xs),
+:global(.playkit-size-ty), {
   .title-wrapper {
     flex-direction: column;
   }


### PR DESCRIPTION
for xs player size, in navigation side panel for quiz items- the question state label ("answered", "correct", "incorrect") should be rendered in a new line, rather than next to the question title (i.e. "Question 1").

Solves [FEC-13097](https://kaltura.atlassian.net/browse/FEC-13097)

[FEC-13097]: https://kaltura.atlassian.net/browse/FEC-13097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ