### PR TITLE
fix(FEC-13129): search in video "more" should say more of what

### DIFF
--- a/src/components/navigation/index.tsx
+++ b/src/components/navigation/index.tsx
@@ -78,13 +78,13 @@ const getItemTypesTranslates = (props: any): ItemTypesTranslates => {
 const translates = (count: number) => {
   return {
     [ItemTypes.All]: <Text id="navigation.all_types">All</Text>,
-    [ItemTypes.AnswerOnAir]: <Text id="navigation.aoa_type" plural={count}>Answer On Air</Text>,
-    [ItemTypes.Chapter]: <Text id="navigation.chapter_type" plural={count}>Chapters</Text>,
-    [ItemTypes.Slide]: <Text id="navigation.slide_type" plural={count}>Slides</Text>,
-    [ItemTypes.Hotspot]: <Text id="navigation.hotspot_type" plural={count}>Hotspots</Text>,
-    [ItemTypes.Caption]: <Text id="navigation.caption_type" plural={count}>Captions</Text>,
-    [ItemTypes.QuizQuestion]: <Text id="navigation.quiz_question_type" plural={count}>Questions</Text>
-  }
+    [ItemTypes.AnswerOnAir]: <Text id="navigation.aoa_type" plural={count}>{`${count === 1 ? 'Answer On Air' : 'Answers On Air'}`}</Text>,
+    [ItemTypes.Chapter]: <Text id="navigation.chapter_type" plural={count}>{`${count === 1 ? 'Chapter' : 'Chapters'}`}</Text>,
+    [ItemTypes.Slide]: <Text id="navigation.slide_type" plural={count}>{`${count === 1 ? 'Slide' : 'Slides'}`}</Text>,
+    [ItemTypes.Hotspot]: <Text id="navigation.hotspot_type" plural={count}>{`${count === 1 ? 'Hotspot' : 'Hotspots'}`}</Text>,
+    [ItemTypes.Caption]: <Text id="navigation.caption_type" plural={count}>{`${count === 1 ? 'Caption' : 'Captions'}`}</Text>,
+    [ItemTypes.QuizQuestion]: <Text id="navigation.quiz_question_type" plural={count}>{`${count === 1 ? 'Question' : 'Questions'}`}</Text>
+  };
 };
 
 @withText(translates(2))

--- a/src/components/navigation/navigation-item/NavigationItem.tsx
+++ b/src/components/navigation/navigation-item/NavigationItem.tsx
@@ -166,8 +166,6 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
       return null;
     }
     const {expandText} = this.state;
-    const readMoreLessLabel = expandText ? this.props.readLessLabel : this.props.readMoreLabel
-    const readMoreLessLabelAria = (readMoreLessLabel).charAt(readMoreLessLabel.length - 1) === 's' ? readMoreLessLabel.substring(0, readMoreLessLabel.length-1) : readMoreLessLabel;
     return (
       <A11yWrapper onClick={this._handleExpandChange}>
         <div
@@ -180,7 +178,7 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
               this._showMoreButtonRef = node;
             }
           }}
-          aria-label={`${readMoreLessLabelAria} ${title}`}>
+          aria-label={`${expandText ? this.props.readLessLabel : this.props.readMoreLabel} ${title}`}>
           {expandText ? this.props.readLessTranslate : this.props.readMoreTranslate}
         </div>
       </A11yWrapper>


### PR DESCRIPTION
**Description of the changes:**
there is a requirement to change the aria labels of More and Less buttons from `Read more about this Slides` to `read more of slide {slide name}`.

Solves [FEC-13129](https://kaltura.atlassian.net/browse/FEC-13129)

[FEC-13129]: https://kaltura.atlassian.net/browse/FEC-13129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ