### PR TITLE
fix(SUP-37655): missing spanish translations for ivq (FEC-37655)

### DIFF
--- a/translations/es.i18n.json
+++ b/translations/es.i18n.json
@@ -16,6 +16,15 @@
       "slide_type": "Diapositivas",
       "hotspot_type": "Puntos de acceso",
       "caption_type": "Subtítulos",
+      "quiz_question_type": {
+        "one": "Pregunta",
+        "many": "Preguntas"
+      },
+      "reflection_point_title": "Punto de reflexión {{index}}",
+      "question_title": "Pregunta {{index}}",
+      "question_answered": "Contestada",
+      "question_incorrect": "Incorrecto",
+      "question_correct": "Correcto",
       "search_result_one_type": {
         "one": "{{totalResults}} resultado en {{type}}",
         "many": "{{totalResults}} resultados en {{type}}"


### PR DESCRIPTION
Added missing translation to some strings in Spanish

Solves [SUP-37655](https://kaltura.atlassian.net/browse/SUP-37655)

[SUP-37655]: https://kaltura.atlassian.net/browse/SUP-37655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ