### PR TITLE
fix(SUP-37655): missing spanish translations for ivq

### DIFF
--- a/translations/es.i18n.json
+++ b/translations/es.i18n.json
@@ -5,6 +5,8 @@
       "show_plugin": "Mostrar navegación",
       "read_less": "Menos",
       "read_more": "Más",
+      "read_more_of": "Mostrar más",
+      "read_less_of": "Mostrar menos",
       "whoops": "¡Vaya!",
       "error_message": "No hemos podido recuperar sus datos.",
       "retry": "Reintentar",
@@ -42,6 +44,7 @@
       "loading": "Cargando",
       "auto_scroll": "Reanudar desplazamiento automático",
       "image_alt": "Previsualización de diapositiva",
+      "list_type": "Enumerar",
       "search_description": "Puede buscar en los subtítulos del video palabras o frases específicas"
     }
   }


### PR DESCRIPTION
Added some missing strings in the Spanish translation

solves [SUP-37655](https://kaltura.atlassian.net/browse/SUP-37655)

[SUP-37655]: https://kaltura.atlassian.net/browse/SUP-37655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ