### PR TITLE
fix(FEC-13332): change side panel behavior triggered by timeline

### DIFF
--- a/src/navigation-plugin.tsx
+++ b/src/navigation-plugin.tsx
@@ -414,7 +414,7 @@ export class NavigationPlugin extends KalturaPlayer.core.BasePlugin {
 
   private _handleTimelinePreviewClick = ({payload}: any) => {
     const {e, byKeyboard, cuePointType} = payload;
-    this._handleClickOnPluginIcon(e, byKeyboard);
+    if (!this.isPluginActive()) this._handleClickOnPluginIcon(e, byKeyboard);
     this._navigationPluginRef?.handleSearchFilterChange('activeTab')(cuePointType);
   }
 


### PR DESCRIPTION
fix behavior when side panel is triggered from timeline repo (click on a title in timeline preview):
- do not close the side panel
- if already open, just focus to the relevant tab (already done today)

Solves FEC-13332