### PR TITLE
fix(SUP-39657): Latest V7 Update Does not Display Description in Chapters

### DIFF
--- a/src/components/navigation/navigation-item/NavigationItem.tsx
+++ b/src/components/navigation/navigation-item/NavigationItem.tsx
@@ -176,7 +176,7 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
           </div>
           <div className={[styles.content, previewImage ? styles.hasImage : null].join(' ')}>
             {this.state.useExpandableText ? (
-              <ExpandableText text={ariaLabelTitle} lines={1}>
+              <ExpandableText text={displayDescription? ariaLabelTitle + displayDescription : ariaLabelTitle} lines={1}>
                 {displayTitle && <span>{displayTitle}</span>}
                 {displayDescription && <div className={styles.description}>{displayDescription}</div>}
               </ExpandableText>


### PR DESCRIPTION
**issue:**
when the chapter has short title the more button is not displayed even if the chapter has a description. 
in addition, when there is no title on the chapter, only a description, nothing is displayed.

**root cause:**
the expandable-text calculate the size of the element per the text (the title from the chapter), so in case the title is short size of the element is appropriate so we doesn't create the more button.

**solution:**
send the title + description as the text to expandable-text