### PR TITLE
fix(FEC-13517): Wrong and inconsistent order of plugins

### DIFF
--- a/src/components/navigation/plugin-button/index.tsx
+++ b/src/components/navigation/plugin-button/index.tsx
@@ -2,7 +2,7 @@ import {h} from 'preact';
 import {ui} from '@playkit-js/kaltura-player-js';
 import * as styles from './plugin-button.scss';
 import {icons} from '../../icons';
-import { pluginName } from "../../../index";
+import { pluginName } from "../../../navigation-plugin";
 
 const {Tooltip, Icon} = KalturaPlayer.ui.components;
 const {withText, Text} = ui.preacti18n;

--- a/src/components/navigation/plugin-button/index.tsx
+++ b/src/components/navigation/plugin-button/index.tsx
@@ -2,6 +2,7 @@ import {h} from 'preact';
 import {ui} from '@playkit-js/kaltura-player-js';
 import * as styles from './plugin-button.scss';
 import {icons} from '../../icons';
+import { pluginName } from "../../../index";
 
 const {Tooltip, Icon} = KalturaPlayer.ui.components;
 const {withText, Text} = ui.preacti18n;
@@ -30,7 +31,7 @@ export const PluginButton = withText(translates)(({isActive, setRef, ...otherPro
           className={[ui.style.upperBarIcon, styles.pluginButton, isActive ? styles.active : ''].join(' ')}
           data-testid={'navigation_pluginButton'}>
           <Icon
-            id="navigation-plugin-button"
+            id={pluginName}
             height={icons.BigSize}
             width={icons.BigSize}
             viewBox={`0 0 ${icons.BigSize} ${icons.BigSize}`}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {NavigationPlugin} from './navigation-plugin';
+import { NavigationPlugin, pluginName } from "./navigation-plugin";
 
 declare var __VERSION__: string;
 declare var __NAME__: string;
@@ -9,5 +9,4 @@ const NAME = __NAME__;
 export {NavigationPlugin as Plugin};
 export {VERSION, NAME};
 
-export const pluginName: string = 'navigation';
 KalturaPlayer.core.registerPlugin(pluginName, NavigationPlugin);

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,5 +9,5 @@ const NAME = __NAME__;
 export {NavigationPlugin as Plugin};
 export {VERSION, NAME};
 
-const pluginName: string = 'navigation';
+export const pluginName: string = 'navigation';
 KalturaPlayer.core.registerPlugin(pluginName, NavigationPlugin);

--- a/src/navigation-plugin.tsx
+++ b/src/navigation-plugin.tsx
@@ -20,7 +20,8 @@ import {PluginButton} from './components/navigation/plugin-button';
 import {icons} from './components/icons';
 import {NavigationConfig, PluginStates, ItemTypes, ItemData, CuePoint, HighlightedMap, CuePointsMap} from './types';
 import {QuizTitle} from './components/navigation/navigation-item/QuizTitle';
-import { pluginName } from "./index";
+
+export const pluginName: string = 'navigation';
 
 const {TimedMetadata} = core;
 const {SidePanelModes, SidePanelPositions, ReservedPresetNames} = ui;

--- a/src/navigation-plugin.tsx
+++ b/src/navigation-plugin.tsx
@@ -20,6 +20,7 @@ import {PluginButton} from './components/navigation/plugin-button';
 import {icons} from './components/icons';
 import {NavigationConfig, PluginStates, ItemTypes, ItemData, CuePoint, HighlightedMap, CuePointsMap} from './types';
 import {QuizTitle} from './components/navigation/navigation-item/QuizTitle';
+import { pluginName } from "./index";
 
 const {TimedMetadata} = core;
 const {SidePanelModes, SidePanelPositions, ReservedPresetNames} = ui;
@@ -370,8 +371,13 @@ export class NavigationPlugin extends KalturaPlayer.core.BasePlugin {
       onDeactivate: this._deactivatePlugin
     }) as number;
 
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     this._navigationIcon = this.upperBarManager!.add({
-      label: 'Navigation',
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      ariaLabel: 'Navigation',
+      displayName: 'Navigation',
       svgIcon: {path: icons.PLUGIN_ICON, viewBox: `0 0 ${icons.BigSize} ${icons.BigSize}`},
       onClick: this._handleClickOnPluginIcon as () => void,
       component: () => {

--- a/src/navigation-plugin.tsx
+++ b/src/navigation-plugin.tsx
@@ -378,6 +378,7 @@ export class NavigationPlugin extends KalturaPlayer.core.BasePlugin {
       // @ts-ignore
       ariaLabel: 'Navigation',
       displayName: 'Navigation',
+      order: 10,
       svgIcon: {path: icons.PLUGIN_ICON, viewBox: `0 0 ${icons.BigSize} ${icons.BigSize}`},
       onClick: this._handleClickOnPluginIcon as () => void,
       component: () => {


### PR DESCRIPTION
### Description of the Changes


**fix: Wrong and inconsistent order of plugins**

**fix: Plugins buttons sometimes display with the wrong icon**

**solves: [FEC-13517](https://kaltura.atlassian.net/browse/FEC-13517) [FEC-13517](https://kaltura.atlassian.net/browse/FEC-13517)**

[FEC-13517]: https://kaltura.atlassian.net/browse/FEC-13517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FEC-13517]: https://kaltura.atlassian.net/browse/FEC-13517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

#### Related Prs
https://github.com/kaltura/playkit-js-ui-managers/pull/51
https://github.com/kaltura/playkit-js-transcript/pull/175
https://github.com/kaltura/playkit-js-share/pull/38
https://github.com/kaltura/playkit-js-moderation/pull/74
https://github.com/kaltura/playkit-js-playlist/pull/53
https://github.com/kaltura/playkit-js-related/pull/61
https://github.com/kaltura/playkit-js-info/pull/90
https://github.com/kaltura/playkit-js-downloads/pull/39
https://github.com/kaltura/playkit-js-qna/pull/334