### PR TITLE
fix(FEC-13889): Download_close being reported too many times to application events

### DIFF
--- a/src/navigation-plugin.tsx
+++ b/src/navigation-plugin.tsx
@@ -369,7 +369,6 @@ export class NavigationPlugin extends KalturaPlayer.core.BasePlugin {
       presets: [ReservedPresetNames.Playback, ReservedPresetNames.Live, ReservedPresetNames.Ads],
       position: this.config.position,
       expandMode: this.config.expandMode === SidePanelModes.ALONGSIDE ? SidePanelModes.ALONGSIDE : SidePanelModes.OVER,
-      onDeactivate: this._deactivatePlugin
     }) as number;
 
     this._navigationIcon = this.upperBarManager!.add({


### PR DESCRIPTION
### Resolves: [FEC-13889](https://kaltura.atlassian.net/browse/FEC-13889)

#### Related PRs:
https://github.com/kaltura/playkit-js-transcript/pull/192
https://github.com/kaltura/playkit-js-qna/pull/342
https://github.com/kaltura/playkit-js-ui-managers/pull/52

[FEC-13889]: https://kaltura.atlassian.net/browse/FEC-13889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ