### PR TITLE
fix(FEC-13929): Application events analytics reporting to kava | Navigation_chapters_see_more & less events doesn't sent for chapters without thumbnail.

### DIFF
--- a/src/components/navigation/navigation-item/NavigationItem.tsx
+++ b/src/components/navigation/navigation-item/NavigationItem.tsx
@@ -184,7 +184,8 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
                 lines={3}
                 className={styles.expandableText}
                 classNameExpanded={styles.expanded}
-                onClick={this._handleExpand}>
+                onClick={this._handleExpand}
+                onExpand={this._onExpand}>
                 {displayDescription}
               </ExpandableText>
             </Localizer>


### PR DESCRIPTION


#### Resloves FEC-13929