### PR TITLE
fix(ADA-1390): Removing aria-hidden from focusable items.

### DIFF
--- a/src/components/navigation/navigation-item/NavigationItem.tsx
+++ b/src/components/navigation/navigation-item/NavigationItem.tsx
@@ -204,7 +204,6 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
       onFocus: this._handleFocus,
       onBlur: this._handleBlur,
       tabIndex: 0,
-      ariaHidden: !(selectedItem || this.state.focused)
     };
 
     const ariaLabelTitle: string = typeof displayTitle === 'string' ? displayTitle : displayDescription || '';


### PR DESCRIPTION
Issue:
aria-hidden item attribute was set on a focusable div.

Fix:
Removing the redundant attribute.