### PR TITLE
fix(ADA-1407): [Strategic Blue / University of Sheffield] - Button element has the wrong role

### DIFF
--- a/src/components/navigation/navigation-item/NavigationItem.tsx
+++ b/src/components/navigation/navigation-item/NavigationItem.tsx
@@ -214,7 +214,7 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
         onClick={this._handleClick}
         onDownKeyPressed={this.props.onNext}
         onUpKeyPressed={this.props.onPrev}
-        role={selectedItem ? 'text' : 'listitem'}>
+        role='button'>
         <div
           tabIndex={0}
           aria-label={ariaLabelTitle}


### PR DESCRIPTION
Change the role of navigation items to "button", since this is a clickable and there is no indication for that.

solves [ADA-1407](https://kaltura.atlassian.net/browse/ADA-1407)

[ADA-1407]: https://kaltura.atlassian.net/browse/ADA-1407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ