### PR TITLE
fix(ADA-1501): [By Applause] Screen Reader: Core Player: Tab/Tab listitems are identified as as Radio buttons by screen reader.

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -200,10 +200,10 @@ describe('Navigation plugin', () => {
         cy.get('[data-testid="navigation_root"]').should('have.css', 'visibility', 'visible');
         cy.get('[data-testid="navigation_root"]').within(() => {
           // default state
-          const tabAll = cy.get("[aria-label='List All']").should('be.visible').should('have.attr', 'aria-checked', 'true');
-          const tabChapters = cy.get("[aria-label='List Chapters']").should('be.visible').should('have.attr', 'aria-checked', 'false');
-          const tabSlides = cy.get("[aria-label='List Slides']").should('be.visible').should('have.attr', 'aria-checked', 'false');
-          const tabHotspots = cy.get("[aria-label='List Hotspots']").should('be.visible').should('have.attr', 'aria-checked', 'false');
+          const tabAll = cy.get("[aria-label='List All']").should('be.visible').should('have.attr', 'aria-selected', 'true');
+          const tabChapters = cy.get("[aria-label='List Chapters']").should('be.visible').should('have.attr', 'aria-selected', 'false');
+          const tabSlides = cy.get("[aria-label='List Slides']").should('be.visible').should('have.attr', 'aria-selected', 'false');
+          const tabHotspots = cy.get("[aria-label='List Hotspots']").should('be.visible').should('have.attr', 'aria-selected', 'false');
           cy.get("[aria-label='Captions']").should('not.exist');
           cy.get("[aria-label='AoA']").should('not.exist');
 
@@ -305,9 +305,9 @@ describe('Navigation plugin', () => {
         const screenReaderWrapper = cy.get('[data-testid="screenReaderWrapper"]');
         screenReaderWrapper.should('exist');
         cy.get('[data-testid="navigation_root"]').within(() => {
-          const tabChapters = cy.get("[aria-label='List Chapters']").should('be.visible').should('have.attr', 'aria-checked', 'false');
+          const tabChapters = cy.get("[aria-label='List Chapters']").should('be.visible').should('have.attr', 'aria-selected', 'false');
           tabChapters.click();
-          tabChapters.should('have.attr', 'aria-checked', 'true');
+          tabChapters.should('have.attr', 'selected-checked', 'true');
           const searchInput = cy.get("[aria-label='Search in video']");
           searchInput.type('c');
           cy.get('[data-testid="navigation_list"]').children().should('have.length', 3);
@@ -340,7 +340,7 @@ describe('Navigation plugin', () => {
         cy.get('[data-testid="navigation_root"]').within(() => {
           cy.get('[data-testid="navigation_list"]').children().should('have.length', 7);
         });
-        const tabQuestions = cy.get("[aria-label='List Questions']").should('be.visible').should('have.attr', 'aria-checked', 'false');
+        const tabQuestions = cy.get("[aria-label='List Questions']").should('be.visible').should('have.attr', 'aria-selected', 'false');
         tabQuestions.click();
         cy.get('[data-testid="navigation_list"]').children().should('have.length', 1);
       });

--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -226,7 +226,7 @@ describe('Navigation plugin', () => {
           cy.get("[aria-label='Hotspots']").should('not.exist');
           cy.get("[aria-label='AoA']").should('not.exist');
           const tabCaptions = cy.get("[aria-label='List Captions']").should('be.visible').click();
-          tabCaptions.should('have.attr', 'aria-checked', 'true');
+          tabCaptions.should('have.attr', 'aria-selected', 'true');
           cy.get('[data-testid="navigation_list"]').children().should('have.length', 5);
         });
       });
@@ -307,7 +307,7 @@ describe('Navigation plugin', () => {
         cy.get('[data-testid="navigation_root"]').within(() => {
           const tabChapters = cy.get("[aria-label='List Chapters']").should('be.visible').should('have.attr', 'aria-selected', 'false');
           tabChapters.click();
-          tabChapters.should('have.attr', 'selected-checked', 'true');
+          tabChapters.should('have.attr', 'aria-selected', 'true');
           const searchInput = cy.get("[aria-label='Search in video']");
           searchInput.type('c');
           cy.get('[data-testid="navigation_list"]').children().should('have.length', 3);

--- a/src/components/navigation-filter/navigation-filter.tsx
+++ b/src/components/navigation-filter/navigation-filter.tsx
@@ -131,13 +131,12 @@ export class NavigationFilter extends Component<FilterProps> {
           onClick={() => this._handleChange(tab.type)}
           onDownKeyPressed={this._handleDownKeyPressed(index)}
           onUpKeyPressed={this._handleUpKeyPressed(index)}
-          role="radio">
+          role="tab">
           <button
             aria-label={`${this.props.listType} ${tab.label}`}
             key={tab.type}
             tabIndex={0}
-            type="checkbox"
-            aria-checked={tab.isActive}
+            aria-selected={tab.isActive}
             className={[styles.tab, tab.isActive ? styles.active : ''].join(' ')}
             ref={node => {
               this._setTabRef(index, node);
@@ -182,7 +181,7 @@ export class NavigationFilter extends Component<FilterProps> {
     return (
       <div className={styles.filterRoot}>
         {totalResults !== 0 && tabs.length >= 2 && (
-          <div className={styles.tabsWrapper} role="radiogroup">
+          <div className={styles.tabsWrapper} role="tablist">
             {tabs.map((tab, index) => {
               return this._renderTab(tab, index);
             })}

--- a/src/components/navigation/navigation-list/NavigationList.tsx
+++ b/src/components/navigation/navigation-list/NavigationList.tsx
@@ -77,7 +77,7 @@ export class NavigationList extends Component<Props> {
       return listDataContainCaptions ? <EmptyState /> : <EmptyList showNoResultsText={searchActive} />;
     }
     return (
-      <div className={styles.navigationList} data-testid="navigation_list" aria-live="polite">
+      <div className={styles.navigationList} data-testid="navigation_list" aria-live="polite" role="tabpanel">
         {data.map((item: ItemData, index: number) => {
           const itemTypeTranslate = this.props.itemTypesTranslates[item.itemType];
           return (


### PR DESCRIPTION
**Issue:**
Screen reader announces the radio button role for the Tab/Tab list items (All, Chapters, Slides, Hotspots) radio role is not appropriate here.

**Fix:**
Change the "radio" to "tab" and "radiogroup" to "tablist", add also role "tabpanel" in the div that display the items for each tab.

Solves [ADA-1501](https://kaltura.atlassian.net/browse/ADA-1501)

[ADA-1501]: https://kaltura.atlassian.net/browse/ADA-1501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ