### PR TITLE
fix(SUP-45356): [Minn State] Issue with Special Characters in Chapter Titles Display on the Player

### DIFF
--- a/src/navigation-plugin.tsx
+++ b/src/navigation-plugin.tsx
@@ -274,8 +274,9 @@ export class NavigationPlugin extends KalturaPlayer.core.BasePlugin {
         }
       }
       if (this._getCuePointType(cue) === ItemTypes.Chapter && this._itemsFilter[ItemTypes.Chapter]) {
-        navigationData.push(prepareCuePoint(cue, ItemTypes.Chapter, isLive));
-        this.timelineManager?.addKalturaCuePoint(cue.startTime, ItemTypes.Chapter, cue.id, cue.metadata.title);
+        const preparedCuePoint: ItemData= prepareCuePoint(cue, ItemTypes.Chapter, isLive)
+        navigationData.push(preparedCuePoint);
+        this.timelineManager?.addKalturaCuePoint(cue.startTime, ItemTypes.Chapter, preparedCuePoint.id, preparedCuePoint.displayTitle);
       }
       if (this._getCuePointType(cue) === ItemTypes.Hotspot && this._itemsFilter[ItemTypes.Hotspot]) {
         navigationData.push(prepareCuePoint(cue, ItemTypes.Hotspot, isLive));


### PR DESCRIPTION
issue:
on timeline when using special characters like & and " it wasn't display correctly

solution:
navigation plugin prepared the cuepoint and did decoding for the title before display it on navigation, so use this for timeline also.

solved [SUP-45356](https://kaltura.atlassian.net/browse/SUP-45356)

[SUP-45356]: https://kaltura.atlassian.net/browse/SUP-45356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ