### PR TITLE
fix(ADA-3331): Fix Navigation item invalid structure

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -146,20 +146,20 @@ describe('Navigation plugin', () => {
       });
     });
 
-    it('should render long title without More button', () => {
+    it('should render long title without toggle button', () => {
       mockKalturaBe();
       loadPlayer({expandOnFirstPlay: true}, {muted: true, autoplay: true}).then(() => {
         cy.get('[data-entry-id="1_02sihd5j"]').within(() => {
-          cy.get('.playkit-more-button-text').should('not.exist');
+          cy.get('button[aria-label="Toggle description"]').should('not.exist');
         });
       });
     });
 
-    it('should render long description with More button', () => {
+    it('should render long description with toggle button', () => {
       mockKalturaBe();
       loadPlayer({expandOnFirstPlay: true}, {muted: true, autoplay: true}).then(() => {
         cy.get('[data-entry-id="1_o6am7wrw"]').within(() => {
-          cy.get('.playkit-more-button-text').should('exist');
+          cy.get('button[aria-label="Toggle description"]').should('exist');
         });
       });
     });

--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -149,7 +149,7 @@ describe('Navigation plugin', () => {
     it('should render long title without toggle button', () => {
       mockKalturaBe();
       loadPlayer({expandOnFirstPlay: true}, {muted: true, autoplay: true}).then(() => {
-        cy.get('[data-entry-id="1_02sihd5j"]').within(() => {
+        cy.get('[data-entry-id="1_02sihd5j"]').parent().within(() => {
           cy.get('button[aria-label="Toggle description"]').should('not.exist');
         });
       });
@@ -158,7 +158,7 @@ describe('Navigation plugin', () => {
     it('should render long description with toggle button', () => {
       mockKalturaBe();
       loadPlayer({expandOnFirstPlay: true}, {muted: true, autoplay: true}).then(() => {
-        cy.get('[data-entry-id="1_o6am7wrw"]').within(() => {
+        cy.get('[data-entry-id="1_o6am7wrw"]').parent().within(() => {
           cy.get('button[aria-label="Toggle description"]').should('exist');
         });
       });

--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -149,7 +149,7 @@ describe('Navigation plugin', () => {
     it('should render long title without toggle button', () => {
       mockKalturaBe();
       loadPlayer({expandOnFirstPlay: true}, {muted: true, autoplay: true}).then(() => {
-        cy.get('[data-entry-id="1_02sihd5j"]').parent().within(() => {
+        cy.get('[data-entry-id="1_02sihd5j"]').closest('[data-testid="nav-item-container"]').within(() => {
           cy.get('button[aria-label="Toggle description"]').should('not.exist');
         });
       });
@@ -158,7 +158,7 @@ describe('Navigation plugin', () => {
     it('should render long description with toggle button', () => {
       mockKalturaBe();
       loadPlayer({expandOnFirstPlay: true}, {muted: true, autoplay: true}).then(() => {
-        cy.get('[data-entry-id="1_o6am7wrw"]').parent().within(() => {
+        cy.get('[data-entry-id="1_o6am7wrw"]').closest('[data-testid="nav-item-container"]').within(() => {
           cy.get('button[aria-label="Toggle description"]').should('exist');
         });
       });

--- a/src/components/navigation/navigation-item/NavigationItem.scss
+++ b/src/components/navigation/navigation-item/NavigationItem.scss
@@ -183,7 +183,7 @@
     transition: transform 0.2s ease;
   }
 
-  &.expanded svg {
+  &.toggle-button-expanded svg {
     transform: rotate(90deg);
   }
 }

--- a/src/components/navigation/navigation-item/NavigationItem.scss
+++ b/src/components/navigation/navigation-item/NavigationItem.scss
@@ -1,37 +1,54 @@
 @import '../../../theme.scss';
 
-.navigation-item {
+.item-container {
   position: relative;
   padding: 8px 8px 8px 0;
   display: flex;
   align-items: flex-start;
-  min-height: 28px;
-  border-left: 2px hidden;
+  gap: 8px;
+  width: 100%;
   background-color: transparent;
   border-radius: 2px;
   border-left: 2px solid transparent;
   -webkit-transition: background-color 0.3s;
   transition: background-color 0.3s;
-  &.hidden .thumbnail {
-    height: 0px;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.2);
   }
-  &.selected {
+
+  &:focus-within {
+    background: rgba(255, 255, 255, 0.2);
+  }
+
+  &:has(.navigation-item.selected) {
     background-color: rgba(255, 255, 255, 0.12);
     border-left: 2px solid $primary-color;
-    &.first {
+
+    &:has(.navigation-item.first) {
       border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
     }
-    &.mid {
+    &:has(.navigation-item.mid) {
       border-radius: 0;
     }
-    &.last {
+    &:has(.navigation-item.last) {
       border-top-left-radius: 0;
       border-top-right-radius: 0;
     }
   }
-  &:hover {
-    background: rgba(255, 255, 255, 0.2);
+}
+
+.navigation-item {
+  position: relative;
+  flex: 1;
+  display: flex;
+  align-items: flex-start;
+  min-height: 28px;
+  background: transparent;
+
+  &.hidden .thumbnail {
+    height: 0px;
   }
   &.first,
   &.single {
@@ -44,18 +61,6 @@
     }
   }
 
-  &.mid,
-  &.first {
-    &:after {
-      content: '';
-      position: absolute;
-      display: block;
-      bottom: 0;
-      width: 100%;
-      height: 1px;
-      background-color: black;
-    }
-  }
 
   .icon-wrapper {
     display: inline-block;
@@ -125,8 +130,71 @@
   }
 }
 
-.expandable-text:not(.expanded) {
+.expandable-text {
   display: flex;
-  justify-content: space-between;
-  gap: 8px;
+  flex-direction: column;
+}
+
+.expanded {
+  display: flex;
+  flex-direction: column;
+}
+
+.clamped-1 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  line-clamp: 1;
+  overflow: hidden;
+}
+
+.clamped-3 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  overflow: hidden;
+}
+
+.toggle-button {
+  display: flex;
+  padding: 0;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 24px;
+  height: 24px;
+  background: var(--B-60, rgba(0, 0, 0, 0.60));
+  border-radius: var(--Roundness-1, 4px);
+  color: #FFF;
+  text-align: right;
+  font-family: Lato, sans-serif;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 18px;
+  cursor: pointer;
+  border: none;
+  transition: background-color 0.2s;
+  align-self: flex-start;
+  flex-shrink: 0;
+
+  svg {
+    transition: transform 0.2s ease;
+  }
+
+  &.expanded svg {
+    transform: rotate(90deg);
+  }
+}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }

--- a/src/components/navigation/navigation-item/NavigationItem.tsx
+++ b/src/components/navigation/navigation-item/NavigationItem.tsx
@@ -123,8 +123,9 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
       previousProps.widgetWidth !== this.props.widgetWidth ||
       previousProps.data.displayDescription !== this.props.data.displayDescription;
     const imageJustLoaded = !previousState.imageLoaded && this.state.imageLoaded;
+    const justCollapsed = previousState.isExpanded && !this.state.isExpanded;
     
-    if (relevantPropsChanged || imageJustLoaded) {
+    if (relevantPropsChanged || imageJustLoaded || justCollapsed) {
       this._checkOverflow();
     }
   }

--- a/src/components/navigation/navigation-item/NavigationItem.tsx
+++ b/src/components/navigation/navigation-item/NavigationItem.tsx
@@ -1,5 +1,6 @@
 import {Component, h, Fragment} from 'preact';
 import {A11yWrapper} from '@playkit-js/common/dist/hoc/a11y-wrapper';
+import {ChevronRight} from '@playkit-js/common/dist/icon/icons/chevronRight';
 import * as styles from './NavigationItem.scss';
 import {GroupTypes, ItemData} from '../../../types';
 import {IconsFactory} from '../icons/IconsFactory';
@@ -9,8 +10,7 @@ const {preacti18n} = ui;
 
 //@ts-ignore
 const {getDurationAsText} = KalturaPlayer.ui.utils;
-const {ExpandableText} = ui.components;
-const {withText, Text, Localizer} = preacti18n;
+const {withText, Text} = preacti18n;
 const {withPlayer} = KalturaPlayer.ui.components;
 
 export interface NavigationItemProps {
@@ -34,6 +34,8 @@ export interface NavigationItemState {
   imageLoaded: boolean;
   imageFailed: boolean;
   useExpandableText: boolean;
+  isExpanded: boolean;
+  announcement: string;
 }
 const translates={
   slideAltText: <Text id="navigation.slide_type.one">Slide</Text>,
@@ -55,13 +57,16 @@ function getAriaLabelTitle(data: ItemData): string {
 export class NavigationItem extends Component<NavigationItemProps, NavigationItemState> {
   private _itemElementRef: HTMLDivElement | null = null;
   private _textContainerRef: HTMLDivElement | null = null;
+  private _announcementTimeout?: number;
 
   constructor(props: NavigationItemProps) {
     super(props);
     this.state = {
       imageLoaded: false,
       imageFailed: false,
-      useExpandableText: typeof this.props.data?.displayTitle === 'string'
+      useExpandableText: typeof this.props.data?.displayTitle === 'string',
+      isExpanded: false,
+      announcement: ''
     };
   }
 
@@ -84,6 +89,8 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
       data !== nextProps.data ||
       nextState.imageLoaded !== this.state.imageLoaded ||
       nextState.imageFailed !== this.state.imageFailed ||
+      nextState.isExpanded !== this.state.isExpanded ||
+      nextState.announcement !== this.state.announcement ||
       nextProps.widgetWidth !== widgetWidth
     ) {
       return true;
@@ -92,6 +99,14 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
   }
 
   componentDidUpdate(previousProps: Readonly<NavigationItemProps>, nextState: Readonly<NavigationItemState>) {
+    if (this.state.announcement) {
+      window.clearTimeout(this._announcementTimeout);
+
+      this._announcementTimeout = window.setTimeout(() => {
+        this.setState({announcement: ''});
+      }, 0);
+    }
+
     this._getSelected();
     this.matchHeight();
   }
@@ -100,7 +115,11 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
     this._getSelected();
     this.matchHeight();
   }
-
+  componentWillUnmount() {
+    if (this._announcementTimeout) {
+      window.clearTimeout(this._announcementTimeout);
+    }
+  }
   private _getSelected = () => {
     const {selectedItem, data} = this.props;
     const {groupData, startTime, previewImage} = data;
@@ -123,12 +142,56 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
     this.props.onClick(this.props.data.startTime, this.props.data.itemType);
   };
 
-  private _onExpand = (isTextExpanded: boolean) => {
-    this.props.dispatcher(NavigationEvent.NAVIGATION_EXPANDABLE_TEXT_CLICK, {isTextExpanded, itemType: this.props.data.itemType});
-  };
-  private _handleExpand = (e: MouseEvent) => {
+  private _toggleExpand = (e: MouseEvent | KeyboardEvent) => {
     e?.stopPropagation();
     e?.preventDefault();
+
+    this.setState((prevState) => {
+      const newExpandedState = !prevState.isExpanded;
+
+      this.props.dispatcher(NavigationEvent.NAVIGATION_EXPANDABLE_TEXT_CLICK, {
+        isTextExpanded: newExpandedState,
+        itemType: this.props.data.itemType
+      });
+
+      let announcement = '';
+
+      if (newExpandedState) {
+        const {displayTitle, displayDescription, startTime} = this.props.data;
+        const timestamp = getDurationAsText(Math.floor(startTime), this.props.player?.config.ui.locale, true);
+        announcement = [`${this.props.timeLabel} ${timestamp}`, displayTitle, displayDescription].filter(Boolean).join('. ');
+      }
+
+      return {
+        isExpanded: newExpandedState,
+        announcement
+      };
+    });
+  };
+
+  private _shouldShowToggleButton = (): boolean => {
+    const {previewImage, displayTitle, displayDescription} = this.props.data;
+    const hasTitle = Boolean(displayTitle || displayDescription);
+    
+    return (previewImage && hasTitle && this.state.useExpandableText) || (!previewImage && Boolean(displayDescription));
+  };
+
+  private _renderToggleButton = () => {
+    if (!this._shouldShowToggleButton()) {
+      return null;
+    }
+
+    return (
+    <button
+      onClick={this._toggleExpand}
+      className={[styles.toggleButton, this.state.isExpanded ? styles.expanded : null].join(' ')}
+      aria-expanded={this.state.isExpanded}
+      aria-controls={`nav-content-${this.props.data.id}`}
+      type="button"
+      aria-label={"Toggle description"}>
+      <ChevronRight />
+    </button>
+    );
   };
 
   private _renderThumbnail = () => {
@@ -154,26 +217,21 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
 
   private _renderTitleAndDescription = (ariaLabelTitle: string) => {
     const {previewImage, displayTitle, displayDescription} = this.props.data;
+    const {isExpanded} = this.state;
     const hasTitle = Boolean(displayTitle || displayDescription);
     if (previewImage && hasTitle) {
       if (this.state.useExpandableText) {
         return (
           <div className={styles.titleWrapper}>
-            <ExpandableText
-              text={ariaLabelTitle || displayDescription || ''}
-              lines={1}
-              forceShowMore={Boolean(displayTitle && displayDescription)}
-              onClick={this._handleExpand}
-              onExpand={this._onExpand}
-              className={styles.expandableText}
-              classNameExpanded={styles.expanded}
-              buttonProps={{
-                tabIndex: 0,
-                role: 'button'
-              }}>
+            <div id={`nav-content-${this.props.data.id}`}>
               {displayTitle && <div className={styles.title}>{displayTitle}</div>}
-              {displayDescription && <div className={styles.descriptionWrapper}>{displayDescription}</div>}
-            </ExpandableText>
+              {displayDescription && (
+                <div 
+                  className={[styles.descriptionWrapper, !isExpanded ? styles['clamped-1'] : null].join(' ')}>
+                  {displayDescription}
+                </div>
+              )}
+            </div>
           </div>
         );
       }
@@ -184,22 +242,11 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
         {displayTitle && <div className={styles.title}>{displayTitle}</div>}
         {displayDescription && (
           <div className={styles.descriptionWrapper}>
-            <Localizer>
-              <ExpandableText
-                buttonProps={{
-                  tabIndex: 0,
-                  readMoreLabel: <Text id="navigation.read_more">Read more</Text>,
-                  readLessLabel: <Text id="navigation.read_less">Read less</Text>
-                }}
-                text={displayDescription}
-                lines={3}
-                className={styles.expandableText}
-                classNameExpanded={styles.expanded}
-                onClick={this._handleExpand}
-                onExpand={this._onExpand}>
-                {displayDescription}
-              </ExpandableText>
-            </Localizer>
+            <div 
+              className={[isExpanded ? styles.expanded : styles.expandableText, !isExpanded ? styles['clamped-3'] : null].join(' ')}
+              id={`nav-content-${this.props.data.id}`}>
+              {displayDescription}
+            </div>
           </div>
         )}
       </Fragment>
@@ -221,33 +268,42 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
     };
 
     return (
-      <A11yWrapper onClick={this._handleClick}>
+      <div className={styles.itemContainer}>
+        <A11yWrapper onClick={this._handleClick}>
+          <div
+            ref={node => {
+              this._itemElementRef = node;
+            }}
+            className={[
+              styles[groupData ? groupData : 'single'],
+              styles.navigationItem,
+              selectedItem ? styles.selected : null,
+              previewImage && !imageLoaded ? styles.hidden : null
+            ].join(' ')}
+            data-entry-id={id}
+            {...a11yProps}>
+            <div className={[styles.metadata, liveCuePoint ? null : styles.withTime].join(' ')}>
+              {!liveCuePoint && <span>{displayTime}</span>}
+              {showIcon && (
+                <div className={styles.iconWrapper}>
+                  <IconsFactory iconType={itemType} />
+                </div>
+              )}
+            </div>
+            <div className={[styles.content, previewImage ? styles.hasImage : null].join(' ')}>
+              {this._renderTitleAndDescription(ariaLabelTitle)}
+              {previewImage && this._renderThumbnail()}
+            </div>
+          </div>
+        </A11yWrapper>
+        {this._renderToggleButton()}
         <div
-          ref={node => {
-            this._itemElementRef = node;
-          }}
-          className={[
-            styles[groupData ? groupData : 'single'],
-            styles.navigationItem,
-            selectedItem ? styles.selected : null,
-            previewImage && !imageLoaded ? styles.hidden : null
-          ].join(' ')}
-          data-entry-id={id}
-          {...a11yProps}>
-          <div className={[styles.metadata, liveCuePoint ? null : styles.withTime].join(' ')}>
-            {!liveCuePoint && <span>{displayTime}</span>}
-            {showIcon && (
-              <div className={styles.iconWrapper}>
-                <IconsFactory iconType={itemType} />
-              </div>
-            )}
-          </div>
-          <div className={[styles.content, previewImage ? styles.hasImage : null].join(' ')}>
-            {this._renderTitleAndDescription(ariaLabelTitle)}
-            {previewImage && this._renderThumbnail()}
-          </div>
+          aria-live="polite"
+          aria-atomic="true"
+          className={styles.srOnly}>
+          {this.state.announcement}
         </div>
-      </A11yWrapper>
+      </div>
     );
   }
 }

--- a/src/components/navigation/navigation-item/NavigationItem.tsx
+++ b/src/components/navigation/navigation-item/NavigationItem.tsx
@@ -312,9 +312,9 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
     const ariaLabelTitle = getAriaLabelTitle(data);
     const timestampLabel = `${timeLabel} ${getDurationAsText(Math.floor(startTime), player?.config.ui.locale, true)}`
     
-    // Include description in aria-label when it exists but doesn't overflow (short description or already expanded)
+    // Include description in aria-label when it is not overflowing
     const descriptionText = typeof displayDescription === 'string' ? displayDescription : '';
-    const includeDescriptionInLabel = descriptionText && (!hasOverflow || isExpanded);
+    const includeDescriptionInLabel = descriptionText && !hasOverflow;
     const ariaLabelParts = [timestampLabel, ariaLabelTitle];
     if (includeDescriptionInLabel) {
       ariaLabelParts.push(descriptionText);

--- a/src/components/navigation/navigation-item/NavigationItem.tsx
+++ b/src/components/navigation/navigation-item/NavigationItem.tsx
@@ -314,7 +314,7 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
     
     // Include description in aria-label when it exists but doesn't overflow (short description or already expanded)
     const descriptionText = typeof displayDescription === 'string' ? displayDescription : '';
-    const includeDescriptionInLabel = descriptionText && !hasOverflow;
+    const includeDescriptionInLabel = descriptionText && (!hasOverflow || isExpanded);
     const ariaLabelParts = [timestampLabel, ariaLabelTitle];
     if (includeDescriptionInLabel) {
       ariaLabelParts.push(descriptionText);

--- a/src/components/navigation/navigation-item/NavigationItem.tsx
+++ b/src/components/navigation/navigation-item/NavigationItem.tsx
@@ -27,6 +27,7 @@ export interface NavigationItemProps {
   slideAltText?: string;
   instructionLabel?: string;
   timeLabel?: string;
+  toggleLabel?: string;
   player?: any;
 }
 
@@ -41,6 +42,7 @@ const translates={
   slideAltText: <Text id="navigation.slide_type.one">Slide</Text>,
   instructionLabel: <Text id="navigation.instruction_label">Jump to this point in video</Text>,
   timeLabel: <Text id="navigation.time_label">Timestamp</Text>,
+  toggleLabel: <Text id="navigation.toggle_description">Toggle description</Text>,
 
 };
 function getAriaLabelTitle(data: ItemData): string {
@@ -188,7 +190,7 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
       aria-expanded={this.state.isExpanded}
       aria-controls={`nav-content-${this.props.data.id}`}
       type="button"
-      aria-label={"Toggle description"}>
+      aria-label={this.props.toggleLabel}>
       <ChevronRight />
     </button>
     );
@@ -255,14 +257,15 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
 
   render() {
     const {data, selectedItem, showIcon, instructionLabel, timeLabel, player} = this.props;
-    const {id, previewImage, itemType, displayTime, liveCuePoint, groupData, displayTitle, displayDescription, startTime} = data;
-    const {imageLoaded} = this.state;
+    const {id, previewImage, itemType, displayTime, liveCuePoint, groupData, displayDescription, startTime} = data;
+    const {imageLoaded, isExpanded} = this.state;
     const ariaLabelTitle = getAriaLabelTitle(data);
     const timestampLabel = `${timeLabel} ${getDurationAsText(Math.floor(startTime), player?.config.ui.locale, true)}`
 
     const a11yProps: Record<string, any> = {
       ['aria-current']: selectedItem,
       ['aria-label']: timestampLabel + " " + ariaLabelTitle + " " + instructionLabel,
+      ['aria-describedby']: isExpanded && displayDescription ? `nav-content-${id}` : undefined,
       tabIndex: 0,
       role: 'button'
     };

--- a/src/components/navigation/navigation-item/NavigationItem.tsx
+++ b/src/components/navigation/navigation-item/NavigationItem.tsx
@@ -37,6 +37,7 @@ export interface NavigationItemState {
   useExpandableText: boolean;
   isExpanded: boolean;
   announcement: string;
+  hasOverflow: boolean;
 }
 const translates={
   slideAltText: <Text id="navigation.slide_type.one">Slide</Text>,
@@ -59,7 +60,9 @@ function getAriaLabelTitle(data: ItemData): string {
 export class NavigationItem extends Component<NavigationItemProps, NavigationItemState> {
   private _itemElementRef: HTMLDivElement | null = null;
   private _textContainerRef: HTMLDivElement | null = null;
+  private _descriptionRef: HTMLDivElement | null = null;
   private _announcementTimeout?: number;
+  private _overflowCheckFrame?: number;
 
   constructor(props: NavigationItemProps) {
     super(props);
@@ -68,7 +71,8 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
       imageFailed: false,
       useExpandableText: typeof this.props.data?.displayTitle === 'string',
       isExpanded: false,
-      announcement: ''
+      announcement: '',
+      hasOverflow: false
     };
   }
 
@@ -93,6 +97,8 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
       nextState.imageFailed !== this.state.imageFailed ||
       nextState.isExpanded !== this.state.isExpanded ||
       nextState.announcement !== this.state.announcement ||
+      nextState.hasOverflow !== this.state.hasOverflow ||
+      nextState.useExpandableText !== this.state.useExpandableText ||
       nextProps.widgetWidth !== widgetWidth
     ) {
       return true;
@@ -100,7 +106,7 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
     return false;
   }
 
-  componentDidUpdate(previousProps: Readonly<NavigationItemProps>, nextState: Readonly<NavigationItemState>) {
+  componentDidUpdate(previousProps: Readonly<NavigationItemProps>, previousState: Readonly<NavigationItemState>) {
     if (this.state.announcement) {
       window.clearTimeout(this._announcementTimeout);
 
@@ -111,15 +117,29 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
 
     this._getSelected();
     this.matchHeight();
+    
+    // Only check overflow when conditions that affect it change
+    const relevantPropsChanged = 
+      previousProps.widgetWidth !== this.props.widgetWidth ||
+      previousProps.data.displayDescription !== this.props.data.displayDescription;
+    const imageJustLoaded = !previousState.imageLoaded && this.state.imageLoaded;
+    
+    if (relevantPropsChanged || imageJustLoaded) {
+      this._checkOverflow();
+    }
   }
 
   componentDidMount() {
     this._getSelected();
     this.matchHeight();
+    this._checkOverflow();
   }
   componentWillUnmount() {
     if (this._announcementTimeout) {
       window.clearTimeout(this._announcementTimeout);
+    }
+    if (this._overflowCheckFrame) {
+      window.cancelAnimationFrame(this._overflowCheckFrame);
     }
   }
   private _getSelected = () => {
@@ -159,9 +179,11 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
       let announcement = '';
 
       if (newExpandedState) {
-        const {displayTitle, displayDescription, startTime} = this.props.data;
+        const {displayDescription, startTime} = this.props.data;
         const timestamp = getDurationAsText(Math.floor(startTime), this.props.player?.config.ui.locale, true);
-        announcement = [`${this.props.timeLabel} ${timestamp}`, displayTitle, displayDescription].filter(Boolean).join('. ');
+        const titleText = getAriaLabelTitle(this.props.data);
+        const descriptionText = typeof displayDescription === 'string' ? displayDescription : '';
+        announcement = [`${this.props.timeLabel} ${timestamp}`, titleText, descriptionText].filter(Boolean).join('. ');
       }
 
       return {
@@ -171,11 +193,35 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
     });
   };
 
-  private _shouldShowToggleButton = (): boolean => {
-    const {previewImage, displayTitle, displayDescription} = this.props.data;
-    const hasTitle = Boolean(displayTitle || displayDescription);
+  private _checkOverflow = () => {
+    // Cancel any pending check
+    if (this._overflowCheckFrame) {
+      window.cancelAnimationFrame(this._overflowCheckFrame);
+    }
     
-    return (previewImage && hasTitle && this.state.useExpandableText) || (!previewImage && Boolean(displayDescription));
+    // Schedule measurement in RAF to batch layout reads and reduce thrashing
+    this._overflowCheckFrame = window.requestAnimationFrame(() => {
+      // Only check overflow when collapsed - when expanded, the content is not clamped
+      if (this.state.isExpanded) {
+        return;
+      }
+      
+      if (!this._descriptionRef || !this.props.data.displayDescription) {
+        if (this.state.hasOverflow) {
+          this.setState({hasOverflow: false});
+        }
+        return;
+      }
+
+      const isOverflowing = this._descriptionRef.scrollHeight > this._descriptionRef.clientHeight;
+      if (isOverflowing !== this.state.hasOverflow) {
+        this.setState({hasOverflow: isOverflowing});
+      }
+    });
+  };
+
+  private _shouldShowToggleButton = (): boolean => {
+    return this.state.hasOverflow;
   };
 
   private _renderToggleButton = () => {
@@ -186,7 +232,7 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
     return (
     <button
       onClick={this._toggleExpand}
-      className={[styles.toggleButton, this.state.isExpanded ? styles.expanded : null].join(' ')}
+      className={[styles.toggleButton, this.state.isExpanded ? styles.toggleButtonExpanded : null].join(' ')}
       aria-expanded={this.state.isExpanded}
       aria-controls={`nav-content-${this.props.data.id}`}
       type="button"
@@ -217,7 +263,7 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
     return <img {...imageProps} />;
   };
 
-  private _renderTitleAndDescription = (ariaLabelTitle: string) => {
+  private _renderTitleAndDescription = () => {
     const {previewImage, displayTitle, displayDescription} = this.props.data;
     const {isExpanded} = this.state;
     const hasTitle = Boolean(displayTitle || displayDescription);
@@ -229,6 +275,7 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
               {displayTitle && <div className={styles.title}>{displayTitle}</div>}
               {displayDescription && (
                 <div 
+                  ref={node => { this._descriptionRef = node; }}
                   className={[styles.descriptionWrapper, !isExpanded ? styles['clamped-1'] : null].join(' ')}>
                   {displayDescription}
                 </div>
@@ -245,6 +292,7 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
         {displayDescription && (
           <div className={styles.descriptionWrapper}>
             <div 
+              ref={node => { this._descriptionRef = node; }}
               className={[isExpanded ? styles.expanded : styles.expandableText, !isExpanded ? styles['clamped-3'] : null].join(' ')}
               id={`nav-content-${this.props.data.id}`}>
               {displayDescription}
@@ -258,14 +306,25 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
   render() {
     const {data, selectedItem, showIcon, instructionLabel, timeLabel, player} = this.props;
     const {id, previewImage, itemType, displayTime, liveCuePoint, groupData, displayDescription, startTime} = data;
-    const {imageLoaded, isExpanded} = this.state;
+    const {imageLoaded, isExpanded, hasOverflow} = this.state;
     const ariaLabelTitle = getAriaLabelTitle(data);
     const timestampLabel = `${timeLabel} ${getDurationAsText(Math.floor(startTime), player?.config.ui.locale, true)}`
+    
+    // Include description in aria-label when it exists but doesn't overflow (short description or already expanded)
+    const descriptionText = typeof displayDescription === 'string' ? displayDescription : '';
+    const includeDescriptionInLabel = descriptionText && !hasOverflow;
+    const ariaLabelParts = [timestampLabel, ariaLabelTitle];
+    if (includeDescriptionInLabel) {
+      ariaLabelParts.push(descriptionText);
+    }
+    if (instructionLabel) {
+      ariaLabelParts.push(instructionLabel);
+    }
 
     const a11yProps: Record<string, any> = {
       ['aria-current']: selectedItem,
-      ['aria-label']: timestampLabel + " " + ariaLabelTitle + " " + instructionLabel,
-      ['aria-describedby']: isExpanded && displayDescription ? `nav-content-${id}` : undefined,
+      ['aria-label']: ariaLabelParts.join(' '),
+      ['aria-describedby']: isExpanded && displayDescription && hasOverflow ? `nav-content-${id}` : undefined,
       tabIndex: 0,
       role: 'button'
     };
@@ -294,7 +353,7 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
               )}
             </div>
             <div className={[styles.content, previewImage ? styles.hasImage : null].join(' ')}>
-              {this._renderTitleAndDescription(ariaLabelTitle)}
+              {this._renderTitleAndDescription()}
               {previewImage && this._renderThumbnail()}
             </div>
           </div>

--- a/src/components/navigation/navigation-item/NavigationItem.tsx
+++ b/src/components/navigation/navigation-item/NavigationItem.tsx
@@ -112,7 +112,7 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
 
       this._announcementTimeout = window.setTimeout(() => {
         this.setState({announcement: ''});
-      }, 0);
+      }, 150);
     }
 
     this._getSelected();
@@ -216,24 +216,25 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
 
       const isOverflowing = this._descriptionRef.scrollHeight > this._descriptionRef.clientHeight;
       if (isOverflowing !== this.state.hasOverflow) {
-        this.setState({hasOverflow: isOverflowing});
+        // Reset isExpanded when overflow disappears to keep state clean
+        const shouldResetExpanded = !isOverflowing && this.state.isExpanded;
+        this.setState({
+          hasOverflow: isOverflowing,
+          ...(shouldResetExpanded ? {isExpanded: false} : {})
+        });
       }
     });
   };
 
-  private _shouldShowToggleButton = (): boolean => {
-    return this.state.hasOverflow;
-  };
-
   private _renderToggleButton = () => {
-    if (!this._shouldShowToggleButton()) {
+    if (!this.state.hasOverflow) {
       return null;
     }
 
     return (
     <button
       onClick={this._toggleExpand}
-      className={[styles.toggleButton, this.state.isExpanded ? styles.toggleButtonExpanded : null].join(' ')}
+      className={[styles.toggleButton, this.state.isExpanded ? styles.toggleButtonExpanded : null].filter(Boolean).join(' ')}
       aria-expanded={this.state.isExpanded}
       aria-controls={`nav-content-${this.props.data.id}`}
       type="button"
@@ -275,9 +276,9 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
             <div id={`nav-content-${this.props.data.id}`}>
               {displayTitle && <div className={styles.title}>{displayTitle}</div>}
               {displayDescription && (
-                <div 
+                <div
                   ref={node => { this._descriptionRef = node; }}
-                  className={[styles.descriptionWrapper, !isExpanded ? styles['clamped-1'] : null].join(' ')}>
+                  className={[styles.descriptionWrapper, !isExpanded ? styles['clamped-1'] : null].filter(Boolean).join(' ')}>
                   {displayDescription}
                 </div>
               )}
@@ -292,9 +293,9 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
         {displayTitle && <div className={styles.title}>{displayTitle}</div>}
         {displayDescription && (
           <div className={styles.descriptionWrapper}>
-            <div 
+            <div
               ref={node => { this._descriptionRef = node; }}
-              className={[isExpanded ? styles.expanded : styles.expandableText, !isExpanded ? styles['clamped-3'] : null].join(' ')}
+              className={[isExpanded ? styles.expanded : styles.expandableText, !isExpanded ? styles['clamped-3'] : null].filter(Boolean).join(' ')}
               id={`nav-content-${this.props.data.id}`}>
               {displayDescription}
             </div>
@@ -331,7 +332,7 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
     };
 
     return (
-      <div className={styles.itemContainer}>
+      <div className={styles.itemContainer} data-testid="nav-item-container">
         <A11yWrapper onClick={this._handleClick}>
           <div
             ref={node => {
@@ -342,10 +343,10 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
               styles.navigationItem,
               selectedItem ? styles.selected : null,
               previewImage && !imageLoaded ? styles.hidden : null
-            ].join(' ')}
+            ].filter(Boolean).join(' ')}
             data-entry-id={id}
             {...a11yProps}>
-            <div className={[styles.metadata, liveCuePoint ? null : styles.withTime].join(' ')}>
+            <div className={[styles.metadata, liveCuePoint ? null : styles.withTime].filter(Boolean).join(' ')}>
               {!liveCuePoint && <span>{displayTime}</span>}
               {showIcon && (
                 <div className={styles.iconWrapper}>
@@ -353,7 +354,7 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
                 </div>
               )}
             </div>
-            <div className={[styles.content, previewImage ? styles.hasImage : null].join(' ')}>
+            <div className={[styles.content, previewImage ? styles.hasImage : null].filter(Boolean).join(' ')}>
               {this._renderTitleAndDescription()}
               {previewImage && this._renderThumbnail()}
             </div>

--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -60,7 +60,8 @@
       "read_more": "Read more",
       "read_less": "Read less",
       "instruction_label": "Jump to this point in video",
-      "time_label": "Timestamp"
+      "time_label": "Timestamp",
+      "toggle_description": "Toggle description"
     }
   }
 }


### PR DESCRIPTION
This fixes https://kaltura.atlassian.net/browse/ADA-3331.
Issue description: The More/Less button from the ExpandableText is rendered inside the NavigationItem that is also a button. This creates an invalid structure.
Changes description: This was redesigned https://www.figma.com/design/8yTuCnuVHLYTFp89w7z05J/%F0%9F%93%BA-Player-v7?node-id=539-88&p=f&m=dev, with a button that is rendered outside of the NavigationItem. This button expands and collapses the description. When this action is performed, the SR will announce the expanded state and also the content of this NavigationItem using aria-live.

Note: The "Toggle description" text from the aria-label has not been discussed with product. It is a suggestion and will be changed in this ticket https://kaltura.atlassian.net/browse/ADA-3332 when Julien returns. It was added here so this won't generate new tickets for missing accessible name