### PR TITLE
fix(ADA-2775): Move focus to Navigation item on preview header activa…

### DIFF
--- a/src/components/navigation/index.tsx
+++ b/src/components/navigation/index.tsx
@@ -106,10 +106,10 @@ class TranslatedNavigationFilter extends Component<Omit<FilterProps, 'itemTypesT
 }
 
 @withText(translates(1))
-class TranslatedNavigationList extends Component<Omit<Props, 'itemTypesTranslates'>> {
+class TranslatedNavigationList extends Component<Omit<Props, 'itemTypesTranslates'> & {onListRef?: (ref: NavigationList | null) => void}> {
   render() {
     const itemTypesTranslates = getItemTypesTranslates(this.props);
-    return <NavigationList {...this.props} itemTypesTranslates={itemTypesTranslates} />;
+    return <NavigationList {...this.props} itemTypesTranslates={itemTypesTranslates} ref={(ref) => this.props.onListRef?.(ref)} />;
   }
 }
 
@@ -117,6 +117,7 @@ export class Navigation extends Component<NavigationProps, NavigationState> {
   private _widgetRootRef: HTMLElement | null = null;
   private _preventScrollEvent = false;
   private _listElementRef: HTMLDivElement | null = null;
+  private _navigationListRef: NavigationList | null = null;
 
   static defaultProps?: {
     retry: () => {};
@@ -192,6 +193,10 @@ export class Navigation extends Component<NavigationProps, NavigationState> {
         });
       }
     }
+  };
+
+  public focusItemById = (itemId: string) => {
+    this._navigationListRef?.focusItemById(itemId);
   };
 
   private _getHeaderStyles = (): string => {
@@ -272,6 +277,7 @@ export class Navigation extends Component<NavigationProps, NavigationState> {
     }
     return (
       <TranslatedNavigationList
+        onListRef={(ref) => (this._navigationListRef = ref)}
         searchActive={searchFilter.searchQuery.length > 0}
         widgetWidth={widgetWidth}
         autoScroll={false} // TODO: temporary disable auto-scroll till https://kaltura.atlassian.net/browse/FEV-804 got a fix

--- a/src/components/navigation/navigation-list/NavigationList.tsx
+++ b/src/components/navigation/navigation-list/NavigationList.tsx
@@ -22,6 +22,7 @@ export interface Props {
 
 export class NavigationList extends Component<Props> {
   private _selectedElementY = 0;
+  private _itemRefs: Map<string, NavigationItem> = new Map();
 
   shouldComponentUpdate(nextProps: Readonly<Props>): boolean {
     if (
@@ -50,6 +51,25 @@ export class NavigationList extends Component<Props> {
     }
   };
 
+  public focusItemById = (itemId: string) => {
+    const item = this._itemRefs.get(itemId);
+    if (!item?.base || !(item.base instanceof HTMLElement)) return;
+
+    // NavigationItem is wrapped by HOCs, so access the focusable element via DOM query
+    const focusableElement = item.base.querySelector(`[data-entry-id="${itemId}"]`);
+    if (focusableElement instanceof HTMLElement) {
+      focusableElement.focus();
+    }
+  };
+
+  private _setItemRef = (id: string, ref: NavigationItem | null) => {
+    if (ref) {
+      this._itemRefs.set(id, ref);
+    } else {
+      this._itemRefs.delete(id);
+    }
+  };
+
   render({data, widgetWidth, showItemsIcons, onSeek, highlightedTime, listDataContainCaptions, searchActive}: Props) {
     if (!data.length) {
       return listDataContainCaptions ? <EmptyState /> : <EmptyList showNoResultsText={searchActive} />;
@@ -60,6 +80,7 @@ export class NavigationList extends Component<Props> {
           return (
             <NavigationItem
               key={item.id}
+              ref={(ref) => this._setItemRef(item.id, ref)}
               widgetWidth={widgetWidth}
               onClick={item.onClick ?? onSeek}
               selectedItem={highlightedTime === item.displayTime}

--- a/src/navigation-plugin.tsx
+++ b/src/navigation-plugin.tsx
@@ -482,12 +482,18 @@ export class NavigationPlugin extends KalturaPlayer.core.BasePlugin {
     if (!this.isVisible()) {
       return;
     }
-    if (!this.isPluginActive()) {
-      this._handleClickOnPluginIcon(e, byKeyboard);
+    const wasActive = this.isPluginActive();
+    if (!wasActive) {
+      // Pass false for byKeyboard to prevent search input from auto-focusing
+      this._handleClickOnPluginIcon(e, false);
     }
     this._navigationPluginRef?.handleSearchFilterChange('activeTab')(cuePoint?.type || ItemTypes.All);
     if (cuePoint) {
       this._seekTo(cuePoint?.startTime, cuePoint?.type);
+      // Move focus to the clicked cuepoint item
+      requestAnimationFrame(() => {
+        this._navigationPluginRef?.focusItemById?.(cuePoint.id);
+      });
     }
   };
 


### PR DESCRIPTION
This fixes https://kaltura.atlassian.net/browse/ADA-2775 by moving focus inside Navigation plugin, when activating the timeline preview header for hotspots on the corresponding Navigation item