### PR TITLE
fix(ADA-2775): Move focus to Navigation Item

### DIFF
--- a/src/components/navigation/index.tsx
+++ b/src/components/navigation/index.tsx
@@ -106,10 +106,10 @@ class TranslatedNavigationFilter extends Component<Omit<FilterProps, 'itemTypesT
 }
 
 @withText(translates(1))
-class TranslatedNavigationList extends Component<Omit<Props, 'itemTypesTranslates'>> {
+class TranslatedNavigationList extends Component<Omit<Props, 'itemTypesTranslates'> & {onListRef?: (ref: NavigationList | null) => void}> {
   render() {
     const itemTypesTranslates = getItemTypesTranslates(this.props);
-    return <NavigationList {...this.props} itemTypesTranslates={itemTypesTranslates} />;
+    return <NavigationList {...this.props} itemTypesTranslates={itemTypesTranslates} ref={(ref) => this.props.onListRef?.(ref)} />;
   }
 }
 
@@ -117,6 +117,7 @@ export class Navigation extends Component<NavigationProps, NavigationState> {
   private _widgetRootRef: HTMLElement | null = null;
   private _preventScrollEvent = false;
   private _listElementRef: HTMLDivElement | null = null;
+  private _navigationListRef: NavigationList | null = null;
 
   static defaultProps?: {
     retry: () => {};
@@ -192,6 +193,10 @@ export class Navigation extends Component<NavigationProps, NavigationState> {
         });
       }
     }
+  };
+
+  public focusItemById = (itemId: string) => {
+    this._navigationListRef?.focusItemById(itemId);
   };
 
   private _getHeaderStyles = (): string => {
@@ -272,6 +277,7 @@ export class Navigation extends Component<NavigationProps, NavigationState> {
     }
     return (
       <TranslatedNavigationList
+        onListRef={(ref) => (this._navigationListRef = ref)}
         searchActive={searchFilter.searchQuery.length > 0}
         widgetWidth={widgetWidth}
         autoScroll={false} // TODO: temporary disable auto-scroll till https://kaltura.atlassian.net/browse/FEV-804 got a fix

--- a/src/components/navigation/index.tsx
+++ b/src/components/navigation/index.tsx
@@ -106,7 +106,7 @@ class TranslatedNavigationFilter extends Component<Omit<FilterProps, 'itemTypesT
 }
 
 @withText(translates(1))
-class TranslatedNavigationList extends Component<Omit<Props, 'itemTypesTranslates'> & {onListRef?: (ref: NavigationList | null) => void}> {
+class TranslatedNavigationList extends Component<Omit<Props, 'itemTypesTranslates'> & {onListRef?: (ref: NavigationList | null) => void; getScrollContainer?: () => HTMLElement | null}> {
   render() {
     const itemTypesTranslates = getItemTypesTranslates(this.props);
     return <NavigationList {...this.props} itemTypesTranslates={itemTypesTranslates} ref={(ref) => this.props.onListRef?.(ref)} />;
@@ -278,6 +278,7 @@ export class Navigation extends Component<NavigationProps, NavigationState> {
     return (
       <TranslatedNavigationList
         onListRef={(ref) => (this._navigationListRef = ref)}
+        getScrollContainer={() => this._listElementRef}
         searchActive={searchFilter.searchQuery.length > 0}
         widgetWidth={widgetWidth}
         autoScroll={false} // TODO: temporary disable auto-scroll till https://kaltura.atlassian.net/browse/FEV-804 got a fix

--- a/src/components/navigation/navigation-item/NavigationItem.tsx
+++ b/src/components/navigation/navigation-item/NavigationItem.tsx
@@ -29,6 +29,7 @@ export interface NavigationItemProps {
   timeLabel?: string;
   toggleLabel?: string;
   player?: any;
+  onFocusableElementReady?: (element: HTMLElement | null) => void;
 }
 
 export interface NavigationItemState {
@@ -134,8 +135,12 @@ export class NavigationItem extends Component<NavigationItemProps, NavigationIte
     this._getSelected();
     this.matchHeight();
     this._checkOverflow();
+    // Expose the focusable element to parent via callback
+    this.props.onFocusableElementReady?.(this._itemElementRef);
   }
   componentWillUnmount() {
+    // Clean up the focusable element reference
+    this.props.onFocusableElementReady?.(null);
     if (this._announcementTimeout) {
       window.clearTimeout(this._announcementTimeout);
     }

--- a/src/components/navigation/navigation-list/NavigationList.tsx
+++ b/src/components/navigation/navigation-list/NavigationList.tsx
@@ -22,6 +22,38 @@ export interface Props {
 
 export class NavigationList extends Component<Props> {
   private _selectedElementY = 0;
+  private _itemRefs: Map<string, NavigationItem> = new Map();
+
+  private _getVerticalScrollAncestor = (element: HTMLElement): HTMLElement | null => {
+    let current: HTMLElement | null = element.parentElement;
+    while (current) {
+      if (current.scrollHeight > current.clientHeight) {
+        return current;
+      }
+      current = current.parentElement;
+    }
+    return null;
+  };
+
+  private _scrollItemIntoViewVertically = (element: HTMLElement): void => {
+    const container = this._getVerticalScrollAncestor(element);
+    if (!container) {
+      return;
+    }
+
+    const containerRect = container.getBoundingClientRect();
+    const elementRect = element.getBoundingClientRect();
+    const padding = 8;
+
+    if (elementRect.top < containerRect.top) {
+      container.scrollTop -= containerRect.top - elementRect.top + padding;
+      return;
+    }
+
+    if (elementRect.bottom > containerRect.bottom) {
+      container.scrollTop += elementRect.bottom - containerRect.bottom + padding;
+    }
+  };
 
   shouldComponentUpdate(nextProps: Readonly<Props>): boolean {
     if (
@@ -50,6 +82,31 @@ export class NavigationList extends Component<Props> {
     }
   };
 
+  public focusItemById = (itemId: string) => {
+    const item = this._itemRefs.get(itemId);
+    if (!item?.base || !(item.base instanceof HTMLElement)) return;
+
+    // NavigationItem is wrapped by HOCs, so access the focusable element via DOM query
+    const focusableElement = item.base.querySelector(`[data-entry-id="${itemId}"]`);
+    if (focusableElement instanceof HTMLElement) {
+      try {
+        focusableElement.focus({preventScroll: true});
+      } catch (_error) {
+        focusableElement.focus();
+      }
+
+      this._scrollItemIntoViewVertically(focusableElement);
+    }
+  };
+
+  private _setItemRef = (id: string, ref: NavigationItem | null) => {
+    if (ref) {
+      this._itemRefs.set(id, ref);
+    } else {
+      this._itemRefs.delete(id);
+    }
+  };
+
   render({data, widgetWidth, showItemsIcons, onSeek, highlightedTime, listDataContainCaptions, searchActive}: Props) {
     if (!data.length) {
       return listDataContainCaptions ? <EmptyState /> : <EmptyList showNoResultsText={searchActive} />;
@@ -60,6 +117,7 @@ export class NavigationList extends Component<Props> {
           return (
             <NavigationItem
               key={item.id}
+              ref={(ref) => this._setItemRef(item.id, ref)}
               widgetWidth={widgetWidth}
               onClick={item.onClick ?? onSeek}
               selectedItem={highlightedTime === item.displayTime}

--- a/src/components/navigation/navigation-list/NavigationList.tsx
+++ b/src/components/navigation/navigation-list/NavigationList.tsx
@@ -18,25 +18,15 @@ export interface Props {
   searchActive: boolean;
   itemTypesTranslates: ItemTypesTranslates;
   dispatcher: (name: string, payload?: any) => void;
+  getScrollContainer?: () => HTMLElement | null;
 }
 
 export class NavigationList extends Component<Props> {
   private _selectedElementY = 0;
-  private _itemRefs: Map<string, NavigationItem> = new Map();
-
-  private _getVerticalScrollAncestor = (element: HTMLElement): HTMLElement | null => {
-    let current: HTMLElement | null = element.parentElement;
-    while (current) {
-      if (current.scrollHeight > current.clientHeight) {
-        return current;
-      }
-      current = current.parentElement;
-    }
-    return null;
-  };
+  private _focusableElements: Map<string, HTMLElement> = new Map();
 
   private _scrollItemIntoViewVertically = (element: HTMLElement): void => {
-    const container = this._getVerticalScrollAncestor(element);
+    const container = this.props.getScrollContainer?.();
     if (!container) {
       return;
     }
@@ -83,27 +73,26 @@ export class NavigationList extends Component<Props> {
   };
 
   public focusItemById = (itemId: string) => {
-    const item = this._itemRefs.get(itemId);
-    if (!item?.base || !(item.base instanceof HTMLElement)) return;
+    const element = this._focusableElements.get(itemId);
+    if (!element) return;
 
-    // NavigationItem is wrapped by HOCs, so access the focusable element via DOM query
-    const focusableElement = item.base.querySelector(`[data-entry-id="${itemId}"]`);
-    if (focusableElement instanceof HTMLElement) {
-      try {
-        focusableElement.focus({preventScroll: true});
-      } catch (_error) {
-        focusableElement.focus();
-      }
-
-      this._scrollItemIntoViewVertically(focusableElement);
+    try {
+      // Use preventScroll to avoid browser-specific scrolling issues (Firefox/Safari)
+      // Scrolling is handled separately by _scrollItemIntoViewVertically
+      element.focus({preventScroll: true});
+    } catch (_error) {
+      // Fallback for browsers that don't support preventScroll option
+      element.focus();
     }
+
+    this._scrollItemIntoViewVertically(element);
   };
 
-  private _setItemRef = (id: string, ref: NavigationItem | null) => {
-    if (ref) {
-      this._itemRefs.set(id, ref);
+  private _handleFocusableElement = (id: string) => (element: HTMLElement | null) => {
+    if (element) {
+      this._focusableElements.set(id, element);
     } else {
-      this._itemRefs.delete(id);
+      this._focusableElements.delete(id);
     }
   };
 
@@ -117,7 +106,7 @@ export class NavigationList extends Component<Props> {
           return (
             <NavigationItem
               key={item.id}
-              ref={(ref) => this._setItemRef(item.id, ref)}
+              onFocusableElementReady={this._handleFocusableElement(item.id)}
               widgetWidth={widgetWidth}
               onClick={item.onClick ?? onSeek}
               selectedItem={highlightedTime === item.displayTime}

--- a/src/navigation-plugin.tsx
+++ b/src/navigation-plugin.tsx
@@ -483,11 +483,16 @@ export class NavigationPlugin extends KalturaPlayer.core.BasePlugin {
       return;
     }
     if (!this.isPluginActive()) {
-      this._handleClickOnPluginIcon(e, byKeyboard);
+      // Pass false for byKeyboard to prevent search input from auto-focusing
+      this._handleClickOnPluginIcon(e, false);
     }
     this._navigationPluginRef?.handleSearchFilterChange('activeTab')(cuePoint?.type || ItemTypes.All);
     if (cuePoint) {
       this._seekTo(cuePoint?.startTime, cuePoint?.type);
+      // Move focus to the clicked cuepoint item
+      requestAnimationFrame(() => {
+        this._navigationPluginRef?.focusItemById?.(cuePoint.id);
+      });
     }
   };
 

--- a/src/navigation-plugin.tsx
+++ b/src/navigation-plugin.tsx
@@ -478,7 +478,7 @@ export class NavigationPlugin extends KalturaPlayer.core.BasePlugin {
   }
 
   private _handleTimelinePreviewClick = (payload: any) => {
-    const {e, byKeyboard, cuePoint} = payload;
+    const {e, cuePoint} = payload;
     if (!this.isVisible()) {
       return;
     }
@@ -491,7 +491,9 @@ export class NavigationPlugin extends KalturaPlayer.core.BasePlugin {
       this._seekTo(cuePoint?.startTime, cuePoint?.type);
       // Move focus to the clicked cuepoint item
       requestAnimationFrame(() => {
-        this._navigationPluginRef?.focusItemById?.(cuePoint.id);
+        requestAnimationFrame(() => {
+          this._navigationPluginRef?.focusItemById?.(cuePoint.id);
+        });
       });
     }
   };


### PR DESCRIPTION
This fixes https://kaltura.atlassian.net/browse/ADA-2775. On the reverted version, a bug appeared on Firefox and Safari. When the focusing was activated, the player content would move/scroll to left, leaving an empty space on the right. Using preventScroll helped partially. This player content movement stopped, but if the Navigation item was at the end of a longer Navigation List, the focus would move on the item, but the list would not autoscroll to make the focused item visible.
To fix this I had to use scroll item into view only inside the list container. I added padding so that the total height would make the entire navigation item visible, instead of being cut.